### PR TITLE
Disable HACS brand check

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -20,3 +20,4 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+          ignore: brands


### PR DESCRIPTION
## Summary
- skip the HACS brand validation during CI so the brand check no longer runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da83d60a908320aa8fe846c9c81af4