### PR TITLE
Enable HACS brand validation

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -20,4 +20,3 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
-          ignore: brands


### PR DESCRIPTION
## Summary
- update the HACS validation workflow to stop ignoring brand checks so the integration brand is validated

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3818a44bc8320aeaec40e724d5d05