### PR TITLE
Allow configuring thermostat hysteresis per zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ thermozona:
         - switch.manifold_living_left
         - switch.manifold_living_right
       temp_sensor: sensor.living_room
+      hysteresis: 0.2
     bathroom:
       circuits:
         - switch.manifold_bathroom
       temp_sensor: sensor.bathroom
 ```
 💡 *Tip*: Each `circuit` is a switch (or `input_boolean`) that opens a manifold loop for that zone. Combine multiple circuits per space for an even temperature.
+
+🧮 *Need tighter control?* Override the per-zone `hysteresis` to change how far above/below the target temperature Thermozona waits before switching. Leave it out to keep the default ±0.3 °C deadband.
 
 ## Connecting Your Heat Pump 🔌
 

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -63,8 +63,10 @@ thermozona:
         - input_boolean.verdeler_1_groep_2
         - input_boolean.verdeler_1_groep_3
       temp_sensor: sensor.test_woonkamer_temperatuur
-    
+      hysteresis: 0.2
+
     keuken:
       circuits:
         - input_boolean.verdeler_1_groep_4
       temp_sensor: sensor.test_keuken_temperatuur
+      hysteresis: 0.25

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -14,11 +14,18 @@ CONF_TEMP_SENSOR = "temp_sensor"
 CONF_OUTSIDE_TEMP_SENSOR = "outside_temp_sensor"
 CONF_FLOW_TEMP_SENSOR = "flow_temp_sensor"
 CONF_HEAT_PUMP_MODE = "heat_pump_mode"
+CONF_HYSTERESIS = "hysteresis"
 
-ZONE_SCHEMA = vol.Schema({
-    vol.Required(CONF_CIRCUITS): [cv.entity_id],
-    vol.Required(CONF_TEMP_SENSOR): cv.entity_id,
-})
+ZONE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CIRCUITS): [cv.entity_id],
+        vol.Required(CONF_TEMP_SENSOR): cv.entity_id,
+        vol.Optional(CONF_HYSTERESIS): vol.All(
+            vol.Coerce(float),
+            vol.Range(min=0, max=5),
+        ),
+    }
+)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/custom_components/thermozona/climate.py
+++ b/custom_components/thermozona/climate.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import CONF_TEMP_SENSOR, DOMAIN
+from . import CONF_HYSTERESIS, CONF_TEMP_SENSOR, DOMAIN
 from .heat_pump import HeatPumpController
 from .helpers import resolve_circuits
 from .thermostat import ThermozonaThermostat
@@ -48,6 +48,7 @@ async def async_setup_entry(
                 circuits,
                 config.get(CONF_TEMP_SENSOR),
                 controller,
+                config.get(CONF_HYSTERESIS),
             )
         )
 

--- a/custom_components/thermozona/thermostat.py
+++ b/custom_components/thermozona/thermostat.py
@@ -23,6 +23,7 @@ from .heat_pump import HeatPumpController
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=1)
+DEFAULT_HYSTERESIS = 0.3
 
 
 class ThermozonaThermostat(ClimateEntity):
@@ -46,6 +47,7 @@ class ThermozonaThermostat(ClimateEntity):
         circuits: list[str],
         temp_sensor: str | None,
         controller: HeatPumpController,
+        hysteresis: float | None,
     ) -> None:
         """Initialize the thermostat."""
         self.hass = hass
@@ -70,6 +72,9 @@ class ThermozonaThermostat(ClimateEntity):
         self._manual_mode: HVACMode = HVACMode.AUTO
         self._effective_mode: HVACMode = HVACMode.AUTO
         self._mode_listener_entity: str | None = None
+        self._hysteresis: float = (
+            hysteresis if hysteresis is not None else DEFAULT_HYSTERESIS
+        )
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -255,7 +260,7 @@ class ThermozonaThermostat(ClimateEntity):
                 effective_mode,
             )
 
-        hysteresis = 0.3  # 0.3°C hysterese
+        hysteresis = self._hysteresis
         target = self._attr_target_temperature
 
         if effective_mode == HVACMode.HEAT:


### PR DESCRIPTION
## Summary
- add an optional hysteresis value to the zone configuration schema
- wire the configured hysteresis into each thermostat with a sensible default
- document the new knob in the README and example configuration

## Testing
- python -m compileall custom_components/thermozona

------
https://chatgpt.com/codex/tasks/task_e_68e3a19ffabc8320b6a6cbd6fdb1dea6