### PR TITLE
Add service to reload Thermozona configuration from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ You can mirror the same pattern for flow-temperature numbers or additional statu
   ```
 - Tail `home-assistant.log` to follow events in real time.
 - Use Developer Tools to inspect the generated climate entities and helper sensors.
+- Changed your YAML config and want to apply it without deleting the integration? Reload
+  Thermozona from the Integrations UI (⋮ → **Reload**) or call the `thermozona.reload`
+  service from Developer Tools → Services to re-import the latest configuration and
+  reload the devices.
 
 ## Roadmap 🧭
 - ⏱️ Support for per-zone run-on times and hysteresis.


### PR DESCRIPTION
## Summary
- add a `thermozona.reload` service that re-imports the YAML configuration and reloads the config entry
- ensure config entry setup re-imports the YAML so the Integrations UI reload button also applies updates
- document how to trigger the reload from the UI or service in the README

## Testing
- python -m compileall custom_components/thermozona

------
https://chatgpt.com/codex/tasks/task_e_68e4bbc527148320a71b88810bce65b4