### PR TITLE
Document reload service in services.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ You can mirror the same pattern for flow-temperature numbers or additional statu
   ```
 - Tail `home-assistant.log` to follow events in real time.
 - Use Developer Tools to inspect the generated climate entities and helper sensors.
+- Changed your YAML config and want to apply it without deleting the integration? Reload
+  Thermozona from the Integrations UI (⋮ → **Reload**) or call the `thermozona.reload`
+  service from Developer Tools → Services to re-import the latest configuration and
+  reload the devices.
 
 ## Roadmap 🧭
 - ⏱️ Support for per-zone run-on times and hysteresis.

--- a/custom_components/thermozona/services.yaml
+++ b/custom_components/thermozona/services.yaml
@@ -1,0 +1,3 @@
+reload:
+  name: Reload Thermozona configuration
+  description: Re-import the Thermozona YAML configuration and reload the integration to apply changes without removing the device.


### PR DESCRIPTION
## Summary
- add a services.yaml entry describing the Thermozona reload service so Home Assistant exposes it in the UI

## Testing
- python -m compileall custom_components/thermozona

------
https://chatgpt.com/codex/tasks/task_e_68e4bbc527148320a71b88810bce65b4