### PR TITLE
docs: clarify YAML configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,19 @@ The dashboard shows one thermostat per zone you define in `configuration.yaml`. 
 3. Add this GitHub repository, set the category to `Integration`, and confirm.
 4. Search for **Thermozona** inside HACS and install it.
 5. Restart Home Assistant so it loads the component.
-6. Go to `Settings -> Devices & Services -> Integrations -> +`, search for **Thermozona**, and follow the config flow. 🪄
+6. Add a `thermozona:` block to your `configuration.yaml` (see [Configuration](#configuration-)).
+7. Restart Home Assistant so it loads the integration with your YAML settings.
 
 ### Manual install (without HACS)
 1. Copy the `custom_components/thermozona` folder into your Home Assistant config directory (`config/custom_components/`).
 2. Restart Home Assistant.
-3. Go to `Settings -> Devices & Services -> Integrations -> +` and search for **Thermozona**.
-4. Follow the config flow to pick zones, sensors, and circuits. 🪄
+3. Edit `configuration.yaml` and add a `thermozona:` block with your zones.
+4. Restart Home Assistant so it loads the integration with your YAML settings.
 
 ## Configuration 🔧
-Prefer YAML? Use this snippet as a starting point:
+> ℹ️ Thermozona is configured **exclusively through YAML**. There is no Add Integration/Config Flow in the UI yet—Home Assistant will pick up your setup from `configuration.yaml` after a restart (or by reloading the integration).
+
+Add this example configuration to `configuration.yaml` to get started:
 
 ```yaml
 thermozona:

--- a/custom_components/thermozona/strings.json
+++ b/custom_components/thermozona/strings.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "abort": {
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration-"
+    }
+  }
+}

--- a/custom_components/thermozona/strings.json
+++ b/custom_components/thermozona/strings.json
@@ -1,7 +1,13 @@
 {
   "config": {
     "abort": {
-      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration-"
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration."
+    },
+    "step": {
+      "user": {
+        "title": "Thermozona setup",
+        "description": "Thermozona is configured via configuration.yaml. Please follow the instructions in the README."
+      }
     }
   }
 }

--- a/custom_components/thermozona/translations/en.json
+++ b/custom_components/thermozona/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "abort": {
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration-"
+    }
+  }
+}

--- a/custom_components/thermozona/translations/en.json
+++ b/custom_components/thermozona/translations/en.json
@@ -1,7 +1,13 @@
 {
   "config": {
     "abort": {
-      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration-"
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration."
+    },
+    "step": {
+      "user": {
+        "title": "Thermozona setup",
+        "description": "Thermozona is configured via configuration.yaml. Please follow the instructions in the README."
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- rephrase the README configuration snippet intro so it points directly to configuration.yaml
- update the configuration_yaml_only abort message to mention adding a `thermozona:` block and restarting Home Assistant

## Testing
- not run (documentation/translation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e4f0389b548320a8e3d0ab341ad976