### PR TITLE
Replace README URL in translations with description placeholder for hassfest compliance

### DIFF
--- a/custom_components/thermozona/config_flow.py
+++ b/custom_components/thermozona/config_flow.py
@@ -19,7 +19,7 @@ class ThermozonaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
         """Import a config entry from configuration.yaml."""
         _LOGGER.debug("Starting async_step_import with config: %s", import_config)
-        
+
         # Voorkom dubbele entries
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
@@ -32,4 +32,9 @@ class ThermozonaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         # We gebruiken alleen configuration.yaml voor setup
-        return self.async_abort(reason="configuration_yaml_only")
+        return self.async_abort(
+            reason="configuration_yaml_only",
+            description_placeholders={
+                "readme_url": "https://github.com/japetheape/thermozona/blob/main/README.md#configuration",
+            },
+        )

--- a/custom_components/thermozona/strings.json
+++ b/custom_components/thermozona/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration."
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: {readme_url}."
     },
     "step": {
       "user": {

--- a/custom_components/thermozona/translations/en.json
+++ b/custom_components/thermozona/translations/en.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: https://github.com/japetheape/thermozona/blob/main/README.md#configuration."
+      "configuration_yaml_only": "Thanks for trying Thermozona! Setup is currently YAML-only. Open configuration.yaml, add a `thermozona:` block with your zones, then restart Home Assistant. The README walks through the required options: {readme_url}."
     },
     "step": {
       "user": {


### PR DESCRIPTION
### Motivation
- The scheduled `hassfest` validation CI was failing because translation strings contained a raw URL, which hassfest disallows for translation values.
- The config flow needed to provide a `description_placeholders` value so the UI abort message can reference the README without embedding the URL in translation files.

### Description
- Replaced the direct README URL in `custom_components/thermozona/strings.json` with the `{readme_url}` placeholder.
- Replaced the direct README URL in `custom_components/thermozona/translations/en.json` with the `{readme_url}` placeholder.
- Updated `custom_components/thermozona/config_flow.py` to supply `description_placeholders` with the README URL for the `configuration_yaml_only` abort message.

### Testing
- The repository's scheduled `hassfest` run previously reported a `failure` due to the translation URL issue, which these changes address.
- No automated tests or CI runs were executed after these changes in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9b51e7388320a4c84b8f3372bee8)