### PR TITLE
Add comprehensive pytest suite for Thermozona integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+import types
+from enum import Enum, IntFlag
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+class _BaseEntity:
+    async def async_added_to_hass(self) -> None:
+        return None
+
+    async def async_will_remove_from_hass(self) -> None:
+        return None
+
+    def async_write_ha_state(self) -> None:
+        return None
+
+
+class _RestoreEntity:
+    async def async_get_last_state(self):
+        return None
+
+
+class _ClimateEntityFeature(IntFlag):
+    TARGET_TEMPERATURE = 1
+    TURN_ON = 2
+    TURN_OFF = 4
+
+
+class _HVACMode(str, Enum):
+    HEAT = "heat"
+    COOL = "cool"
+    AUTO = "auto"
+    OFF = "off"
+
+
+class _HVACAction(str, Enum):
+    OFF = "off"
+    HEATING = "heating"
+    COOLING = "cooling"
+    IDLE = "idle"
+
+
+class _Platform(str, Enum):
+    CLIMATE = "climate"
+    NUMBER = "number"
+    SELECT = "select"
+    SENSOR = "sensor"
+
+
+class _UnitOfTemperature(str, Enum):
+    CELSIUS = "°C"
+
+
+class _EntityCategory(str, Enum):
+    CONFIG = "config"
+    DIAGNOSTIC = "diagnostic"
+
+
+class _ConfigFlow:
+    async def async_set_unique_id(self, *_):
+        return None
+
+    def _abort_if_unique_id_configured(self):
+        return None
+
+    def async_create_entry(self, *, title, data):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    def async_abort(self, *, reason, description_placeholders=None):
+        return {
+            "type": "abort",
+            "reason": reason,
+            "description_placeholders": description_placeholders,
+        }
+
+    def __init_subclass__(cls, **kwargs):
+        return super().__init_subclass__()
+
+
+class _State:
+    def __init__(self, state):
+        self.state = state
+
+
+class FakeStates:
+    def __init__(self):
+        self._states: dict[str, _State] = {}
+
+    def get(self, entity_id: str):
+        return self._states.get(entity_id)
+
+    def set(self, entity_id: str, value):
+        self._states[entity_id] = _State(value)
+
+
+class FakeServices:
+    def __init__(self, hass):
+        self.calls: list[tuple[str, str, dict, bool]] = []
+        self._hass = hass
+
+    async def async_call(self, domain, service, data, blocking=False):
+        self.calls.append((domain, service, data, blocking))
+        entity_id = data.get("entity_id")
+        if domain in {"input_boolean", "switch"} and entity_id:
+            self._hass.states.set(entity_id, "on" if service == "turn_on" else "off")
+        if domain == "input_number" and service == "set_value" and entity_id:
+            self._hass.states.set(entity_id, str(data.get("value")))
+
+    def async_register(self, *_args, **_kwargs):
+        return None
+
+
+class FakeConfigEntries:
+    def async_entries(self, _domain):
+        return []
+
+    def async_update_entry(self, _entry, data):
+        return data
+
+    async def async_reload(self, _entry_id):
+        return None
+
+    async def async_forward_entry_setups(self, _entry, _platforms):
+        return None
+
+    async def async_unload_platforms(self, _entry, _platforms):
+        return True
+
+    @property
+    def flow(self):
+        return types.SimpleNamespace(async_init=lambda *args, **kwargs: None)
+
+
+class FakeHass:
+    def __init__(self):
+        self.states = FakeStates()
+        self.services = FakeServices(self)
+        self.data = {}
+        self.config_entries = FakeConfigEntries()
+
+    def async_create_task(self, coro):
+        return asyncio.create_task(coro)
+
+
+class ConfigEntry:
+    def __init__(self, entry_id="entry-1", data=None):
+        self.entry_id = entry_id
+        self.data = data or {}
+
+
+def pytest_configure():
+    ha = types.ModuleType("homeassistant")
+
+    config = types.ModuleType("homeassistant.config")
+
+    async def async_hass_config_yaml(_hass):
+        return {}
+
+    config.async_hass_config_yaml = async_hass_config_yaml
+
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = FakeHass
+    core.ServiceCall = dict
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = ConfigEntry
+    config_entries.SOURCE_IMPORT = "import"
+    config_entries.ConfigFlow = _ConfigFlow
+
+    const = types.ModuleType("homeassistant.const")
+    const.Platform = _Platform
+    const.ATTR_TEMPERATURE = "temperature"
+    const.UnitOfTemperature = _UnitOfTemperature
+
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    exceptions.HomeAssistantError = type("HomeAssistantError", (Exception,), {})
+
+    cv = types.ModuleType("homeassistant.helpers.config_validation")
+    cv.entity_id = str
+    cv.string = str
+
+    entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+    entity_platform.AddEntitiesCallback = object
+
+    entity = types.ModuleType("homeassistant.helpers.entity")
+    entity.EntityCategory = _EntityCategory
+
+    restore_state = types.ModuleType("homeassistant.helpers.restore_state")
+    restore_state.RestoreEntity = _RestoreEntity
+
+    event = types.ModuleType("homeassistant.helpers.event")
+    event.async_track_state_change_event = lambda *_args, **_kwargs: (lambda: None)
+    event.async_track_time_interval = lambda *_args, **_kwargs: (lambda: None)
+
+    climate = types.ModuleType("homeassistant.components.climate")
+    climate.HVACMode = _HVACMode
+    climate.HVACAction = _HVACAction
+    climate.ClimateEntity = _BaseEntity
+    climate.ClimateEntityFeature = _ClimateEntityFeature
+
+    number = types.ModuleType("homeassistant.components.number")
+    number.NumberEntity = _BaseEntity
+
+    select = types.ModuleType("homeassistant.components.select")
+    select.SelectEntity = _BaseEntity
+
+    sensor = types.ModuleType("homeassistant.components.sensor")
+    sensor.SensorEntity = _BaseEntity
+
+    data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+    data_entry_flow.FlowResult = dict
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.config_validation = cv
+
+    components = types.ModuleType("homeassistant.components")
+
+    sys.modules.update(
+        {
+            "homeassistant": ha,
+            "homeassistant.config": config,
+            "homeassistant.core": core,
+            "homeassistant.config_entries": config_entries,
+            "homeassistant.const": const,
+            "homeassistant.exceptions": exceptions,
+            "homeassistant.helpers": helpers,
+            "homeassistant.helpers.config_validation": cv,
+            "homeassistant.helpers.entity_platform": entity_platform,
+            "homeassistant.helpers.entity": entity,
+            "homeassistant.helpers.restore_state": restore_state,
+            "homeassistant.helpers.event": event,
+            "homeassistant.components": components,
+            "homeassistant.components.climate": climate,
+            "homeassistant.components.number": number,
+            "homeassistant.components.select": select,
+            "homeassistant.components.sensor": sensor,
+            "homeassistant.data_entry_flow": data_entry_flow,
+        }
+    )
+
+    ha.components = components
+
+
+__all__ = ["FakeHass", "ConfigEntry"]
+
+
+@pytest.fixture
+def fake_hass() -> FakeHass:
+    return FakeHass()

--- a/tests/test_thermozona.py
+++ b/tests/test_thermozona.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.thermozona.helpers import resolve_circuits
+from custom_components.thermozona.heat_pump import HeatPumpController
+from custom_components.thermozona.thermostat import ThermozonaThermostat
+from homeassistant.components.climate import HVACAction, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE
+
+
+class DummyNumber:
+    def __init__(self):
+        self.values: list[float] = []
+
+    def set_calculated_value(self, value: float) -> None:
+        self.values.append(value)
+
+
+class DummySensor:
+    def __init__(self):
+        self.states: list[str] = []
+
+    def update_state(self, state: str) -> None:
+        self.states.append(state)
+
+
+class DummySelect:
+    def __init__(self):
+        self.entity_id = "select.mode"
+        self.options: list[str] = []
+
+    def update_current_option(self, option: str) -> None:
+        self.options.append(option)
+
+
+class DummyThermostat:
+    def __init__(self):
+        self.calls = 0
+
+    def async_schedule_control(self) -> None:
+        self.calls += 1
+
+    async def async_update_mode_listener(self) -> None:
+        return None
+
+
+def _config(**overrides):
+    base = {
+        "outside_temp_sensor": "sensor.outside",
+        "flow_temp_sensor": "input_number.flow",
+        "zones": {
+            "living_room": {
+                "circuits": ["switch.zone_1"],
+                "temp_sensor": "sensor.living",
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_resolve_circuits_supports_new_and_legacy_keys():
+    assert resolve_circuits({"circuits": ["switch.a"]}) == ["switch.a"]
+    assert resolve_circuits({"groups": ["switch.b"]}) == ["switch.b"]
+    assert resolve_circuits({}) == []
+
+
+def test_auto_mode_and_flow_temperature_calculation_uses_zone_status():
+    controller = HeatPumpController(SimpleNamespace(states=None), _config())
+    controller.update_zone_status("living", target=21, current=19, active=True)
+    assert controller.determine_auto_mode() == HVACMode.HEAT
+
+    flow = controller.determine_flow_temperature(HVACMode.HEAT, outside_temp=5)
+    assert flow > 24
+
+    controller.update_zone_status("living", target=21, current=23, active=True)
+    assert controller.determine_auto_mode() == HVACMode.COOL
+    cool_flow = controller.determine_flow_temperature(HVACMode.COOL, outside_temp=30)
+    assert 15 <= cool_flow <= 25
+
+
+def test_get_operation_mode_maps_external_states(fake_hass):
+    controller = HeatPumpController(fake_hass, _config(heat_pump_mode="sensor.mode"))
+
+    fake_hass.states.set("sensor.mode", "heating")
+    assert controller.get_operation_mode() == "heat"
+
+    fake_hass.states.set("sensor.mode", "cooling")
+    assert controller.get_operation_mode() == "cool"
+
+    fake_hass.states.set("sensor.mode", "idle")
+    assert controller.get_operation_mode() == "off"
+
+
+@pytest.mark.asyncio
+async def test_async_set_flow_temperature_updates_number_entity(fake_hass):
+    controller = HeatPumpController(fake_hass, _config(flow_temp_sensor=None))
+    number = DummyNumber()
+    controller.register_flow_temperature_number(number)
+
+    fake_hass.states.set("sensor.outside", "10")
+    controller.update_zone_status("living", target=21, current=19, active=True)
+
+    mode = await controller._async_set_flow_temperature()
+
+    assert mode == HVACMode.HEAT
+    assert number.values
+
+
+@pytest.mark.asyncio
+async def test_async_update_heat_pump_state_updates_status_sensor(fake_hass):
+    controller = HeatPumpController(fake_hass, _config())
+    sensor = DummySensor()
+    controller.register_pump_sensor(sensor)
+
+    fake_hass.states.set("switch.zone_1", "on")
+    fake_hass.states.set("sensor.outside", "10")
+    controller.update_zone_status("living", target=21, current=19, active=True)
+
+    await controller.async_update_heat_pump_state()
+
+    assert sensor.states[-1] in {"heat", "cool"}
+
+
+@pytest.mark.asyncio
+async def test_set_mode_value_normalizes_invalid_option_and_notifies_thermostats(fake_hass):
+    controller = HeatPumpController(fake_hass, _config())
+    select = DummySelect()
+    thermostat = DummyThermostat()
+
+    controller.register_thermostat(thermostat)
+    controller.register_mode_select(select)
+    controller.set_mode_value("INVALID")
+
+    assert controller.get_operation_mode() == "auto"
+    assert select.options[-1] == "auto"
+    assert thermostat.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_thermostat_controls_circuits_and_updates_hvac_action(fake_hass):
+    controller = HeatPumpController(fake_hass, _config())
+    thermostat = ThermozonaThermostat(
+        fake_hass,
+        "entry-1",
+        "living-room",
+        ["switch.zone_1"],
+        "sensor.living",
+        controller,
+        hysteresis=0.2,
+    )
+
+    fake_hass.states.set("sensor.outside", "9")
+    fake_hass.states.set("sensor.living", "19")
+    fake_hass.states.set("switch.zone_1", "off")
+
+    await thermostat.async_set_temperature(**{ATTR_TEMPERATURE: 21})
+
+    assert thermostat.hvac_mode == HVACMode.AUTO
+    assert thermostat._attr_hvac_action == HVACAction.HEATING
+    assert fake_hass.states.get("switch.zone_1").state == "on"
+
+
+@pytest.mark.asyncio
+async def test_thermostat_turn_off_closes_circuits(fake_hass):
+    controller = HeatPumpController(fake_hass, _config())
+    thermostat = ThermozonaThermostat(
+        fake_hass,
+        "entry-1",
+        "bedroom",
+        ["switch.zone_2"],
+        "sensor.bed",
+        controller,
+        hysteresis=None,
+    )
+
+    fake_hass.states.set("switch.zone_2", "on")
+    fake_hass.states.set("sensor.bed", "20")
+
+    await thermostat.async_turn_off()
+
+    assert thermostat.hvac_mode == HVACMode.OFF
+    assert fake_hass.states.get("switch.zone_2").state == "off"
+
+
+def test_name_helpers_cover_slugify_and_prettify():
+    assert ThermozonaThermostat._prettify("living_room-main") == "Living room main"
+    assert ThermozonaThermostat._slugify("Living Room Main!") == "living_room_main"


### PR DESCRIPTION
### Motivation
- Provide a lightweight, runnable test-suite that validates core Thermozona logic (controller, thermostat, helpers) without requiring a full Home Assistant runtime.

### Description
- Add `tests/conftest.py` which injects minimal Home Assistant stubs, helpers, and a `fake_hass` pytest fixture so integration code can be imported and exercised in unit tests.
- Add `tests/test_thermozona.py` containing tests for `resolve_circuits`, `HeatPumpController` behavior (auto mode switching, flow-temperature calculation, external mode mapping, pump status updates, and mode select interaction), and `ThermozonaThermostat` control behavior (circuit switching, HVAC action, turn_off, and name helpers).
- Apply small test stability adjustments to support async tests and ensure deterministic assertions.

### Testing
- Executed `pytest -q` and verified the suite completed successfully with `9 passed`.
- Addressed initial collection/runtime issues (module path and async support) during test development so the final run is green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698443aaa8ac8320b7766f691d03707b)