### PR TITLE
Add flow temperature sensor for long-term history

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Prefer more aggressive or gentler cooling? Tweak `cooling_base_offset`. The defa
 Thermozona exposes two key helpers for the plant side:
 - `sensor.thermozona_heat_pump_status` reports the current demand direction (`heat`, `cool`, or `idle`). Use it to decide whether your heat pump should run and which mode it needs.
 - `number.thermozona_flow_temperature` publishes the target flow temperature that Thermozona calculated from the active zones and weather curve. Push that value to your heat pump (or manifold) so the generated supply water matches the demand.
+- `sensor.thermozona_flow_temperature` mirrors the same calculated flow temperature as a measurement sensor, so Home Assistant can keep long-term temperature history and statistics.
 
 Mirror these entities through the protocol your heat pump supports (Modbus, KNX, MQTT, …) so the physical unit follows Thermozona’s lead.
 


### PR DESCRIPTION
### Motivation
- Allow Home Assistant to retain long-term history/statistics of the computed flow temperature instead of only exposing it as a transient `number` helper.
- The existing `number.thermozona_flow_temperature` is useful for pushing setpoints but does not provide `device_class`/`state_class` needed for measurement statistics.
- Expose the flow temperature as a proper measurement sensor so automations and dashboards can consume historic values and statistics.

### Description
- Add `ThermozonaFlowTemperatureSensor` (in `custom_components/thermozona/sensor.py`) which sets `device_class=temperature` and `state_class=measurement` and is created alongside the heat pump status sensor.
- Extend `HeatPumpController` (in `custom_components/thermozona/heat_pump.py`) to register/unregister the new sensor, cache the last calculated flow temperature, and push each newly calculated flow temperature to the sensor when updated.
- Update the README to document the new `sensor.thermozona_flow_temperature` helper and its purpose for long-term history/statistics.

### Testing
- Ran `python -m compileall custom_components/thermozona` to verify the modified modules compile successfully, and the command completed without errors.
- Performed a local inspection of the updated files to ensure the new sensor is instantiated and hooked into the controller, with no syntax issues detected by compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698439c3749883208fc8afe11380b4b8)