### PR TITLE
Add UI-adjustable flow curve offset with reset behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ thermozona:
   outside_temp_sensor: sensor.outdoor
   heating_base_offset: 3.0  # Optional: raise/lower the base heating offset
   cooling_base_offset: 2.5  # Optional: make cooling supply warmer/colder
+  flow_curve_offset: 0.0    # Optional: nudge the curve up/down for fine tuning
   zones:
     living_room:
       circuits:
@@ -85,10 +86,13 @@ Thermozona thinks in **zones** because that is how you want to control comfort�
 ### Fine-tuning the heating curve
 
 Thermozona starts its heating curve with a **3 K base offset** above the warmest active zone. Adjust `heating_base_offset` if your installation—radiators, thick screed floors, or fan coils—needs more or less supply temperature to stay comfortable.
+Need a tiny adjustment without touching the base curve? Use `flow_curve_offset` to shift the entire flow temperature curve up or down (positive values raise supply temperature, negative values lower it).
+You can tune this value directly in the UI via `number.thermozona_flow_curve_offset`. If you reload/reset Thermozona, it is restored to the YAML-configured `flow_curve_offset` value.
 
 ### Fine-tuning the cooling curve
 
 Prefer more aggressive or gentler cooling? Tweak `cooling_base_offset`. The default is **2.5 K below the coldest requested zone**. A lower offset (for example 2.0) keeps the supply water warmer for softer cooling, while a higher offset strengthens the cooling effect.
+You can also apply `flow_curve_offset` here to nudge the cooling curve up or down.
 🧮 *Need tighter control?* Override the per-zone `hysteresis` to change how far above/below the target temperature Thermozona waits before switching. Leave it out to keep the default ±0.3 °C deadband.
 
 ## Connecting Your Heat Pump 🔌

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -58,6 +58,7 @@ thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
   heating_base_offset: 3.0
   cooling_base_offset: 2.5
+  flow_curve_offset: 0.0
   zones:
     woonkamer:
       circuits:

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -20,9 +20,11 @@ CONF_FLOW_TEMP_SENSOR = "flow_temp_sensor"
 CONF_HEAT_PUMP_MODE = "heat_pump_mode"
 CONF_HEATING_BASE_OFFSET = "heating_base_offset"
 CONF_COOLING_BASE_OFFSET = "cooling_base_offset"
+CONF_FLOW_CURVE_OFFSET = "flow_curve_offset"
 
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
+DEFAULT_FLOW_CURVE_OFFSET = 0.0
 CONF_HYSTERESIS = "hysteresis"
 
 ZONE_SCHEMA = vol.Schema(
@@ -48,6 +50,10 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(
             CONF_COOLING_BASE_OFFSET,
             default=DEFAULT_COOLING_BASE_OFFSET,
+        ): vol.Coerce(float),
+        vol.Optional(
+            CONF_FLOW_CURVE_OFFSET,
+            default=DEFAULT_FLOW_CURVE_OFFSET,
         ): vol.Coerce(float),
         vol.Required(CONF_ZONES): {
             cv.string: ZONE_SCHEMA

--- a/custom_components/thermozona/number.py
+++ b/custom_components/thermozona/number.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN
+from . import DEFAULT_FLOW_CURVE_OFFSET, DOMAIN
 from .heat_pump import HeatPumpController
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,7 +34,10 @@ async def async_setup_entry(
     controllers[config_entry.entry_id] = controller
 
     async_add_entities(
-        [ThermozonaFlowTemperatureNumber(config_entry.entry_id, controller)]
+        [
+            ThermozonaFlowTemperatureNumber(config_entry.entry_id, controller),
+            ThermozonaFlowCurveOffsetNumber(config_entry.entry_id, controller),
+        ]
     )
 
 
@@ -82,5 +85,51 @@ class ThermozonaFlowTemperatureNumber(NumberEntity):
 
     def set_calculated_value(self, value: float) -> None:
         """Update the number with the latest calculated flow temperature."""
+        self._attr_native_value = round(value, 1)
+        self.async_write_ha_state()
+
+
+class ThermozonaFlowCurveOffsetNumber(NumberEntity):
+    """Expose flow curve offset as an editable UI number."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Flow Curve Offset"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_native_min_value = -5.0
+    _attr_native_max_value = 5.0
+    _attr_native_step = 0.1
+    _attr_icon = "mdi:tune-variant"
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        entry_id: str,
+        controller: HeatPumpController,
+    ) -> None:
+        self._controller = controller
+        self._attr_unique_id = f"{entry_id}_flow_curve_offset"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry_id)},
+            "name": "Thermozona",
+        }
+        self._attr_native_value: float = DEFAULT_FLOW_CURVE_OFFSET
+
+    async def async_added_to_hass(self) -> None:
+        """Register with the heat pump controller."""
+        await super().async_added_to_hass()
+        self._controller.register_flow_curve_offset_number(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister when the entity is removed."""
+        self._controller.unregister_flow_curve_offset_number(self)
+        await super().async_will_remove_from_hass()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist a new runtime flow curve offset from the UI."""
+        self._controller.set_flow_curve_offset(value)
+
+    def set_current_value(self, value: float) -> None:
+        """Update the UI number to the active offset value."""
         self._attr_native_value = round(value, 1)
         self.async_write_ha_state()


### PR DESCRIPTION
### Motivation
- Provide a way to nudge the entire flow-temperature curve from the Home Assistant UI without editing YAML so users can quickly fine-tune supply temperature. 
- Ensure UI changes are temporary and restored to the YAML-configured value on reload/reset so the YAML remains authoritative.

### Description
- Add a new config number entity `ThermozonaFlowCurveOffsetNumber` (`number.thermozona_flow_curve_offset`) with bounds and step, and expose it in the number platform (`custom_components/thermozona/number.py`).
- Extend `HeatPumpController` with runtime override support (`get_flow_curve_offset`, `set_flow_curve_offset`, `reset_flow_curve_offset`), registration/unregistration of the new UI number, and notify thermostats on changes (`custom_components/thermozona/heat_pump.py`).
- Apply the active flow curve offset (UI override or YAML default) in both heating and cooling branches of `determine_flow_temperature` so the UI value immediately affects flow calculations. 
- Add `CONF_FLOW_CURVE_OFFSET` and `DEFAULT_FLOW_CURVE_OFFSET` to the integration config schema and include `flow_curve_offset` in the example YAML and README documentation to describe UI tuning and reset behavior (`custom_components/thermozona/__init__.py`, `configuration.yaml.example`, `README.md`).

### Testing
- Ran `python -m compileall custom_components/thermozona` to validate modules compile successfully and the integration files compile without syntax errors (succeeded).
- No automated unit tests were added or executed beyond the compilation check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da64b643483208b53a963a144a720)