### PR TITLE
Add per-zone PWM control mode with PI controller and timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ thermozona:
         - switch.manifold_living_right
       temp_sensor: sensor.living_room
       hysteresis: 0.2
+      control_mode: pwm        # Optional: bang_bang (default) or pwm
+      pwm_cycle_time: 15       # Optional: 5-30 minutes (default 15)
+      pwm_min_on_time: 3       # Optional: 1-10 minutes (default 3)
+      pwm_min_off_time: 3      # Optional: 1-10 minutes (default 3)
+      pwm_kp: 30.0             # Optional: proportional gain
+      pwm_ki: 2.0              # Optional: integral gain
     bathroom:
       circuits:
         - switch.manifold_bathroom
@@ -90,6 +96,26 @@ Thermozona starts its heating curve with a **3 K base offset** above the warme
 
 Prefer more aggressive or gentler cooling? Tweak `cooling_base_offset`. The default is **2.5 K below the coldest requested zone**. A lower offset (for example 2.0) keeps the supply water warmer for softer cooling, while a higher offset strengthens the cooling effect.
 🧮 *Need tighter control?* Override the per-zone `hysteresis` to change how far above/below the target temperature Thermozona waits before switching. Leave it out to keep the default ±0.3 °C deadband.
+
+
+### Per-zone control strategy: Bang-bang vs PWM
+
+Thermozona supports two zone control strategies:
+
+- `bang_bang` (default): classic hysteresis switching using `hysteresis` around the setpoint.
+- `pwm`: PI-driven pulse-width modulation to reduce overshoot in high thermal-mass floors.
+
+When `control_mode: pwm` is enabled on a zone, Thermozona calculates a duty cycle (0–100%) every PWM cycle and turns all zone circuits on/off for the corresponding time slice.
+
+#### PWM options (per zone)
+
+- `pwm_cycle_time` *(default: 15, range: 5-30 min)* — total cycle length.
+- `pwm_min_on_time` *(default: 3, range: 1-10 min)* — minimum on pulse for thermal actuators.
+- `pwm_min_off_time` *(default: 3, range: 1-10 min)* — minimum off pulse.
+- `pwm_kp` *(default: 30.0)* — proportional gain (% output per °C error).
+- `pwm_ki` *(default: 2.0)* — integral gain (% output per accumulated °C·minute).
+
+Use `pwm` for slow floor loops that overshoot with on/off control; keep `bang_bang` for simpler zones where hysteresis already behaves well.
 
 ## Connecting Your Heat Pump 🔌
 

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -20,10 +20,26 @@ CONF_FLOW_TEMP_SENSOR = "flow_temp_sensor"
 CONF_HEAT_PUMP_MODE = "heat_pump_mode"
 CONF_HEATING_BASE_OFFSET = "heating_base_offset"
 CONF_COOLING_BASE_OFFSET = "cooling_base_offset"
+CONF_CONTROL_MODE = "control_mode"
+CONF_PWM_CYCLE_TIME = "pwm_cycle_time"
+CONF_PWM_MIN_ON_TIME = "pwm_min_on_time"
+CONF_PWM_MIN_OFF_TIME = "pwm_min_off_time"
+CONF_PWM_KP = "pwm_kp"
+CONF_PWM_KI = "pwm_ki"
+
+CONTROL_MODE_BANG_BANG = "bang_bang"
+CONTROL_MODE_PWM = "pwm"
 
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
 CONF_HYSTERESIS = "hysteresis"
+
+DEFAULT_CONTROL_MODE = CONTROL_MODE_BANG_BANG
+DEFAULT_PWM_CYCLE_TIME = 15
+DEFAULT_PWM_MIN_ON_TIME = 3
+DEFAULT_PWM_MIN_OFF_TIME = 3
+DEFAULT_PWM_KP = 30.0
+DEFAULT_PWM_KI = 2.0
 
 ZONE_SCHEMA = vol.Schema(
     {
@@ -33,6 +49,30 @@ ZONE_SCHEMA = vol.Schema(
             vol.Coerce(float),
             vol.Range(min=0, max=5),
         ),
+        vol.Optional(
+            CONF_CONTROL_MODE,
+            default=DEFAULT_CONTROL_MODE,
+        ): vol.In([CONTROL_MODE_BANG_BANG, CONTROL_MODE_PWM]),
+        vol.Optional(
+            CONF_PWM_CYCLE_TIME,
+            default=DEFAULT_PWM_CYCLE_TIME,
+        ): vol.All(vol.Coerce(int), vol.Range(min=5, max=30)),
+        vol.Optional(
+            CONF_PWM_MIN_ON_TIME,
+            default=DEFAULT_PWM_MIN_ON_TIME,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+        vol.Optional(
+            CONF_PWM_MIN_OFF_TIME,
+            default=DEFAULT_PWM_MIN_OFF_TIME,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+        vol.Optional(
+            CONF_PWM_KP,
+            default=DEFAULT_PWM_KP,
+        ): vol.Coerce(float),
+        vol.Optional(
+            CONF_PWM_KI,
+            default=DEFAULT_PWM_KI,
+        ): vol.Coerce(float),
     }
 )
 

--- a/custom_components/thermozona/climate.py
+++ b/custom_components/thermozona/climate.py
@@ -5,7 +5,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import CONF_HYSTERESIS, CONF_TEMP_SENSOR, DOMAIN
+from . import (
+    CONF_CONTROL_MODE,
+    CONF_HYSTERESIS,
+    CONF_PWM_CYCLE_TIME,
+    CONF_PWM_KI,
+    CONF_PWM_KP,
+    CONF_PWM_MIN_OFF_TIME,
+    CONF_PWM_MIN_ON_TIME,
+    CONF_TEMP_SENSOR,
+    DOMAIN,
+)
 from .heat_pump import HeatPumpController
 from .helpers import resolve_circuits
 from .thermostat import ThermozonaThermostat
@@ -49,6 +59,12 @@ async def async_setup_entry(
                 config.get(CONF_TEMP_SENSOR),
                 controller,
                 config.get(CONF_HYSTERESIS),
+                config.get(CONF_CONTROL_MODE),
+                config.get(CONF_PWM_CYCLE_TIME),
+                config.get(CONF_PWM_MIN_ON_TIME),
+                config.get(CONF_PWM_MIN_OFF_TIME),
+                config.get(CONF_PWM_KP),
+                config.get(CONF_PWM_KI),
             )
         )
 


### PR DESCRIPTION
### Motivation
- Floor heating using bang-bang on/off control causes large temperature swings due to thermal mass and high supply temperature, so a per-zone PWM alternative is needed to reduce overshoot and cycling.  
- The goal is to provide a configurable PWM strategy per zone (via YAML) while preserving existing bang-bang behavior for backward compatibility.

### Description
- Add new zone configuration keys and defaults in `custom_components/thermozona/__init__.py`: `control_mode`, `pwm_cycle_time`, `pwm_min_on_time`, `pwm_min_off_time`, `pwm_kp`, `pwm_ki`, plus `CONTROL_MODE_PWM`/`CONTROL_MODE_BANG_BANG` constants and validation ranges.  
- Plumb PWM options through `custom_components/thermozona/climate.py` so each `ThermozonaThermostat` receives the zone's control strategy and tuning parameters at creation.  
- Implement PWM mode in `custom_components/thermozona/thermostat.py` with a PI controller (proportional + integral), anti-windup clamping, duty→on/off time conversion inside a PWM cycle, enforcement of minimum on/off times, cycle scheduling on the existing 1‑minute tick, and reset behavior when HVAC mode is turned off or target jumps significantly.  
- Persist and restore the PWM integral using the existing `RestoreEntity` mechanism and expose diagnostic attributes via `extra_state_attributes` (`control_mode`, `pwm_duty_cycle`, `pwm_on_time`, `pwm_cycle_time`, `pwm_integral`); existing bang-bang behavior is unchanged for non-PWM zones.  
- Add unit tests exercising PI clamping, minimum-time application in cycles, and runtime PWM behavior, and update existing tests to pass new constructor arguments.

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`12 passed`).  
- Unit tests were added/updated to cover `PI` duty calculation clamping, PWM cycle minimum on‑time handling, and that a PWM zone exposes the `control_mode` attribute and toggles circuits within a cycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987628b5f288320975846d361630981)