### PR TITLE
Add UI flow-curve offset helper and runtime override in HeatPumpController

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ thermozona:
   outside_temp_sensor: sensor.outdoor
   heating_base_offset: 3.0  # Optional: raise/lower the base heating offset
   cooling_base_offset: 2.5  # Optional: make cooling supply warmer/colder
+  flow_curve_offset: 0.0    # Optional baseline for UI flow-curve tuning
   zones:
     living_room:
       circuits:
@@ -95,6 +96,7 @@ Thermozona starts its heating curve with a **3 K base offset** above the warme
 ### Fine-tuning the cooling curve
 
 Prefer more aggressive or gentler cooling? Tweak `cooling_base_offset`. The default is **2.5 K below the coldest requested zone**. A lower offset (for example 2.0) keeps the supply water warmer for softer cooling, while a higher offset strengthens the cooling effect.
+Need quick day-to-day adjustment without editing YAML? Use `number.thermozona_flow_curve_offset` in the UI to temporarily nudge the whole flow-temperature curve up or down (applied to both heating and cooling calculations). Thermozona resets this helper to the YAML value (`flow_curve_offset`) when the integration reloads/restarts, so YAML remains the source of truth.
 🧮 *Need tighter control?* Override the per-zone `hysteresis` to change how far above/below the target temperature Thermozona waits before switching. Leave it out to keep the default ±0.3 °C deadband.
 
 
@@ -123,6 +125,7 @@ Thermozona exposes two key helpers for the plant side:
 - `sensor.thermozona_heat_pump_status` reports the current demand direction (`heat`, `cool`, or `idle`). Use it to decide whether your heat pump should run and which mode it needs.
 - `number.thermozona_flow_temperature` publishes the target flow temperature that Thermozona calculated from the active zones and weather curve. Push that value to your heat pump (or manifold) so the generated supply water matches the demand.
 - `sensor.thermozona_flow_temperature` mirrors the same calculated flow temperature as a measurement sensor, so Home Assistant can keep long-term temperature history and statistics.
+- `number.thermozona_flow_curve_offset` lets you temporarily shift the entire curve from the UI; reload/reset returns it to the YAML `flow_curve_offset` value.
 
 Mirror these entities through the protocol your heat pump supports (Modbus, KNX, MQTT, …) so the physical unit follows Thermozona’s lead.
 

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -58,6 +58,7 @@ thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
   heating_base_offset: 3.0
   cooling_base_offset: 2.5
+  flow_curve_offset: 0.0  # Optional UI baseline; UI tweaks reset on reload
   zones:
     woonkamer:
       circuits:

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -20,6 +20,7 @@ CONF_FLOW_TEMP_SENSOR = "flow_temp_sensor"
 CONF_HEAT_PUMP_MODE = "heat_pump_mode"
 CONF_HEATING_BASE_OFFSET = "heating_base_offset"
 CONF_COOLING_BASE_OFFSET = "cooling_base_offset"
+CONF_FLOW_CURVE_OFFSET = "flow_curve_offset"
 CONF_CONTROL_MODE = "control_mode"
 CONF_PWM_CYCLE_TIME = "pwm_cycle_time"
 CONF_PWM_MIN_ON_TIME = "pwm_min_on_time"
@@ -32,6 +33,7 @@ CONTROL_MODE_PWM = "pwm"
 
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
+DEFAULT_FLOW_CURVE_OFFSET = 0.0
 CONF_HYSTERESIS = "hysteresis"
 
 DEFAULT_CONTROL_MODE = CONTROL_MODE_BANG_BANG
@@ -88,6 +90,10 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(
             CONF_COOLING_BASE_OFFSET,
             default=DEFAULT_COOLING_BASE_OFFSET,
+        ): vol.Coerce(float),
+        vol.Optional(
+            CONF_FLOW_CURVE_OFFSET,
+            default=DEFAULT_FLOW_CURVE_OFFSET,
         ): vol.Coerce(float),
         vol.Required(CONF_ZONES): {
             cv.string: ZONE_SCHEMA

--- a/custom_components/thermozona/number.py
+++ b/custom_components/thermozona/number.py
@@ -34,7 +34,10 @@ async def async_setup_entry(
     controllers[config_entry.entry_id] = controller
 
     async_add_entities(
-        [ThermozonaFlowTemperatureNumber(config_entry.entry_id, controller)]
+        [
+            ThermozonaFlowTemperatureNumber(config_entry.entry_id, controller),
+            ThermozonaFlowCurveOffsetNumber(config_entry.entry_id, controller),
+        ]
     )
 
 
@@ -84,3 +87,56 @@ class ThermozonaFlowTemperatureNumber(NumberEntity):
         """Update the number with the latest calculated flow temperature."""
         self._attr_native_value = round(value, 1)
         self.async_write_ha_state()
+
+
+class ThermozonaFlowCurveOffsetNumber(NumberEntity):
+    """Expose runtime flow-curve offset control as a Home Assistant number."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Flow Curve Offset"
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_native_min_value = -10.0
+    _attr_native_max_value = 10.0
+    _attr_native_step = 0.5
+    _attr_icon = "mdi:tune-variant"
+    _attr_object_id = "thermozona_flow_curve_offset"
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        entry_id: str,
+        controller: HeatPumpController,
+    ) -> None:
+        self._controller = controller
+        self._attr_unique_id = f"{entry_id}_flow_curve_offset"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry_id)},
+            "name": "Thermozona",
+        }
+        self._attr_native_value = controller.get_flow_curve_offset()
+
+    async def async_added_to_hass(self) -> None:
+        """Register with heat pump controller."""
+        await super().async_added_to_hass()
+        self._controller.register_flow_curve_offset_number(self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister when the entity is removed."""
+        self._controller.unregister_flow_curve_offset_number(self)
+        await super().async_will_remove_from_hass()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current active offset value."""
+        return self._attr_native_value
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set runtime flow-curve offset override."""
+        self._controller.set_flow_curve_offset(value)
+
+    def set_current_value(self, value: float) -> None:
+        """Update state from controller (used on reset/reload)."""
+        self._attr_native_value = round(value, 1)
+        self.async_write_ha_state()
+


### PR DESCRIPTION
### Motivation

- Allow quick, temporary tuning of the weather-compensated flow-temperature curve from the Home Assistant UI without editing YAML.
- Ensure any UI tuning is temporary and restored to the YAML-configured baseline on reload/reset so YAML remains the source of truth.

### Description

- Add a new number helper entity `ThermozonaFlowCurveOffsetNumber` exposed as `number.thermozona_flow_curve_offset` with bounds and step and wire it into the `number` platform (`custom_components/thermozona/number.py`).
- Extend `HeatPumpController` with runtime override support and lifecycle methods: `get_flow_curve_offset`, `set_flow_curve_offset`, `reset_flow_curve_offset`, and register/unregister helpers to notify thermostats on change (`custom_components/thermozona/heat_pump.py`).
- Apply the active flow-curve offset (UI override if present, otherwise YAML `flow_curve_offset`) in both the heating and cooling branches of `determine_flow_temperature` so UI changes immediately affect flow calculations (`custom_components/thermozona/heat_pump.py`).
- Add `CONF_FLOW_CURVE_OFFSET` and `DEFAULT_FLOW_CURVE_OFFSET` to the integration config schema, include `flow_curve_offset` in `configuration.yaml.example`, update `README.md` to document the new YAML option and `number.thermozona_flow_curve_offset` behavior, and add controller-focused unit tests validating override, application and reset (`custom_components/thermozona/__init__.py`, `configuration.yaml.example`, `README.md`, `tests/test_thermozona.py`).

### Testing

- Ran `python -m compileall custom_components/thermozona tests` to validate modules compile successfully (succeeded).
- Attempted to run `pytest -q`, but test collection failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'voluptuous'`), so the newly added unit tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876546135083208cc5d297da11aa39)