### PR TITLE
Optimize PWM cycles for longer scheduled heat pump runs

### DIFF
--- a/tests/test_thermozona.py
+++ b/tests/test_thermozona.py
@@ -240,10 +240,27 @@ def test_pwm_cycle_applies_minimum_times(fake_hass):
     thermostat._attr_target_temperature = 20
 
     now = datetime.utcnow()
-    thermostat._start_new_pwm_cycle(current_temp=19.7, effective_mode=HVACMode.HEAT, now=now)
+    cycle_start = thermostat._get_aligned_pwm_cycle_start(now)
+    thermostat._start_new_pwm_cycle(
+        current_temp=19.7,
+        effective_mode=HVACMode.HEAT,
+        now=now,
+        cycle_start=cycle_start,
+        was_active=False,
+    )
 
     assert thermostat._pwm_on_time.total_seconds() / 60 >= 3
-    assert thermostat._pwm_cycle_start == now
+    assert thermostat._pwm_cycle_start == cycle_start
+
+
+def test_pwm_cycle_is_aligned_to_schedule(fake_hass):
+    controller = HeatPumpController(fake_hass, _config())
+    thermostat = _create_pwm_thermostat(fake_hass, controller)
+
+    now = datetime(2024, 1, 1, 12, 7, 42)
+    aligned = thermostat._get_aligned_pwm_cycle_start(now)
+
+    assert aligned == datetime(2024, 1, 1, 12, 0, 0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent PWM cycles from drifting with control-loop timing and make zone runs start on predictable wall-clock boundaries so the heat pump can perform longer, scheduled runs.
- Reduce short-cycling by preserving already-active zones when the computed next OFF window would violate configured minimum off-time constraints.

### Description
- Align PWM cycles to fixed wall-clock intervals via the new helper ` _get_aligned_pwm_cycle_start(now)` and use the aligned slot to start cycles instead of drifting from control-loop timestamps.
- Rework cycle start logic to call ` _start_new_pwm_cycle(...)` when the aligned schedule slot changes and pass `was_active` context so we can prefer continuous ON runs when appropriate.
- Adjust minimum off/on handling so short OFF windows are avoided for already-active zones by forcing a full-cycle ON when needed.
- Updated `tests/test_thermozona.py` to call the new `_start_new_pwm_cycle` signature and added `test_pwm_cycle_is_aligned_to_schedule` to verify alignment.

### Testing
- Ran `pytest -q` in the project; initial collection failed due to missing test dependencies which were installed (`voluptuous` and `pytest-asyncio`) and then re-run.
- Final test run executed `pytest -q` and all tests passed: `13 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698767c634c08320a29b48b18c5efc2e)