### PR TITLE
Add PWM zone staggering and actuator delay compensation

### DIFF
--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -27,6 +27,7 @@ CONF_PWM_MIN_ON_TIME = "pwm_min_on_time"
 CONF_PWM_MIN_OFF_TIME = "pwm_min_off_time"
 CONF_PWM_KP = "pwm_kp"
 CONF_PWM_KI = "pwm_ki"
+CONF_PWM_ACTUATOR_DELAY = "pwm_actuator_delay"
 
 CONTROL_MODE_BANG_BANG = "bang_bang"
 CONTROL_MODE_PWM = "pwm"
@@ -42,6 +43,7 @@ DEFAULT_PWM_MIN_ON_TIME = 3
 DEFAULT_PWM_MIN_OFF_TIME = 3
 DEFAULT_PWM_KP = 30.0
 DEFAULT_PWM_KI = 2.0
+DEFAULT_PWM_ACTUATOR_DELAY = 3
 
 ZONE_SCHEMA = vol.Schema(
     {
@@ -75,6 +77,10 @@ ZONE_SCHEMA = vol.Schema(
             CONF_PWM_KI,
             default=DEFAULT_PWM_KI,
         ): vol.Coerce(float),
+        vol.Optional(
+            CONF_PWM_ACTUATOR_DELAY,
+            default=DEFAULT_PWM_ACTUATOR_DELAY,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
     }
 )
 

--- a/custom_components/thermozona/climate.py
+++ b/custom_components/thermozona/climate.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import (
     CONF_CONTROL_MODE,
     CONF_HYSTERESIS,
+    CONF_PWM_ACTUATOR_DELAY,
     CONF_PWM_CYCLE_TIME,
     CONF_PWM_KI,
     CONF_PWM_KP,
@@ -65,6 +66,7 @@ async def async_setup_entry(
                 config.get(CONF_PWM_MIN_OFF_TIME),
                 config.get(CONF_PWM_KP),
                 config.get(CONF_PWM_KI),
+                config.get(CONF_PWM_ACTUATOR_DELAY),
             )
         )
 


### PR DESCRIPTION
### Motivation
- Prevent simultaneous PWM cycle starts across zones to avoid heatpump demand spikes and compressor short-cycling by deterministically staggering PWM cycles.
- Compensate for thermal actuator warm-up (3–5 min) so short PWM on-times actually deliver water flow and heating.

### Description
- Add new per-zone config `pwm_actuator_delay` (default `3`, range `0..10`) to schema and expose `DEFAULT_PWM_ACTUATOR_DELAY` and `CONF_PWM_ACTUATOR_DELAY` in `__init__.py`.
- Wire `pwm_actuator_delay` through `climate.py` into the `ThermozonaThermostat` constructor so each thermostat can configure delay independently.
- Implement deterministic PWM indexing and bookkeeping in `HeatPumpController` by assigning a stable `pwm_zone_index` on registration and exposing `get_pwm_zone_info()` for thermostats; bang-bang zones are excluded from PWM indexing.
- Update `ThermozonaThermostat` to store `pwm_actuator_delay`, obtain its `(zone_index, zone_count)` from the controller, apply a per-zone staggered offset when computing aligned cycle starts, extend non-zero PWM on-time by the actuator delay (clamped to cycle time), and expose debug attributes `pwm_actuator_delay`, `pwm_zone_index`, and `pwm_zone_count`.
- Add and update unit tests in `tests/test_thermozona.py` to cover PWM staggering behavior (indices, offsets, spacing, bang-bang exclusion) and actuator-delay behavior (extension, zero-duty, clamp, default).

### Testing
- Ran the full test suite with `pytest -q`; all tests passed: `24 passed` including the new PWM staggering and actuator delay tests.
- The test run validates PWM index assignment, staggered cycle-start computation, on-time extension by actuator delay, clamping to cycle length, and that bang-bang zones remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988eca148588320b73bc830033b00b7)