### PR TITLE
Fix PWM timezone handling so cycles activate correctly outside UTC

### DIFF
--- a/custom_components/thermozona/thermostat.py
+++ b/custom_components/thermozona/thermostat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -359,7 +359,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
         effective_mode: HVACMode,
     ) -> None:
         """PI + PWM control with scheduled cycles."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         cycle_time = timedelta(minutes=self._pwm_cycle_time_minutes)
         cycle_start = self._get_aligned_pwm_cycle_start(now)
         active_before = self._circuits_are_active()
@@ -435,7 +435,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             if aligned_timestamp > timestamp:
                 aligned_timestamp -= cycle_seconds
 
-        return datetime.utcfromtimestamp(aligned_timestamp)
+        return datetime.fromtimestamp(aligned_timestamp, tz=timezone.utc)
 
     def _calculate_pwm_duty(
         self,


### PR DESCRIPTION
### Motivation
- PWM-controlled zones were never activating on systems not configured to UTC because naive `datetime.utcnow()` values were interpreted as local time when converted to timestamps, causing cycle alignment to be offset.

### Description
- Use timezone-aware UTC timestamps by importing `timezone` and replacing `datetime.utcnow()` with `datetime.now(timezone.utc)` in `_control_heating_pwm()`.
- Return an aware UTC `datetime` from `_get_aligned_pwm_cycle_start()` by using `datetime.fromtimestamp(..., tz=timezone.utc)` instead of `datetime.utcfromtimestamp()`.
- Update unit tests to use timezone-aware datetimes and add `test_pwm_cycle_alignment_handles_non_utc_timezones` which verifies alignment for a non-UTC input timezone (CET).

### Testing
- Ran `pytest -q` after adding `voluptuous` and `pytest-asyncio` dev deps, and all tests passed: `25 passed`.
- The test suite exercises PWM alignment and PI/PWM behavior including the new non-UTC timezone regression test which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f1b9aaa48320aae9949f25cc64dc)