### PR TITLE
Add configurable flow modes and Pro supervisor control

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Thermozona is community-funded. The core integration stays open and free, while 
 | Warmtepomp status entities | Stagger optimization across zones |
 |  | Actuator delay compensation |
 
-`license_key` must be a valid signed JWT and is validated locally (signature + claims + time window) at integration load time. There is no cloud dependency.
+`pro.license_key` must be a valid signed JWT and is validated locally (signature + claims + time window) at integration load time. There is no cloud dependency.
+
+You will be able to get a Sponsor token at `https://github.com/sponsors/thermozona`. This is not online yet; in the meantime, request a token by email at `info@thermozona.com`.
 
 ## Pro license generation
 
@@ -70,11 +72,12 @@ python scripts/verify_pro_license.py "<jwt-token>"
 
 Place the generated token in `configuration.yaml`:
 
-   ```yaml
-   thermozona:
-     license_key: "<jwt-token>"
-     flow_mode: pro_supervisor  # Pro only; falls back to simple without valid token
-   ```
+```yaml
+thermozona:
+  pro:
+    license_key: "<jwt-token>"
+  # flow_mode: pro_supervisor  # Optional override; auto-selects pro_supervisor when license is valid
+```
 
 ⚠️ Never commit private keys to this repository, Home Assistant config backups, CI logs, or shell history.
 
@@ -138,8 +141,7 @@ Add this example configuration to `configuration.yaml` to get started:
 ```yaml
 thermozona:
   outside_temp_sensor: sensor.outdoor
-  license_key: eyJhbGciOi...<signed_pro_token>  # Optional: unlocks Sponsor License features
-  flow_mode: simple  # Optional: simple (free) or pro_supervisor (Pro License)
+  # flow_mode: simple  # Optional override: simple or pro_supervisor
   heating_base_offset: 3.0  # Optional: raise/lower the base heating offset
   cooling_base_offset: 2.5  # Optional: make cooling supply warmer/colder
   flow_curve_offset: 0.0    # Optional baseline for UI flow-curve tuning
@@ -148,31 +150,33 @@ thermozona:
   simple_flow:              # Optional free-tier write behavior
     write_deadband_c: 0.5
     write_min_interval_minutes: 15
-  pro_flow:                 # Optional Pro supervisor tuning
-    kp: 1.0
-    use_integral: false
-    ti_minutes: 180
-    i_max: 1.5
-    error_norm_max: 2.0
-    duty_ema_minutes: 20
-    error_weight: 0.6
-    duty_weight: 0.4
-    slow_mix_weight: 0.8
-    fast_mix_weight: 0.2
-    fast_error_deadband_c: 0.4
-    fast_boost_gain: 1.2
-    fast_boost_cap_c: 1.2
-    slew_up_c_per_5m: 0.3
-    slew_down_c_per_5m: 0.2
-    write_deadband_c: 0.3
-    write_min_interval_minutes: 10
-    preheat_enabled: false
-    preheat_forecast_sensor: sensor.outdoor_forecast_2h
-    preheat_solar_sensor: sensor.solar_irradiance_forecast_2h
-    preheat_gain: 0.35
-    preheat_solar_gain_per_w_m2: 0.0
-    preheat_cap_c: 1.2
-    preheat_min_slow_di: 0.25
+  pro:                      # Optional Sponsor License config
+    license_key: eyJhbGciOi...<signed_pro_token>
+    flow:                   # Optional Pro supervisor tuning
+      kp: 1.0
+      use_integral: false
+      ti_minutes: 180
+      i_max: 1.5
+      error_norm_max: 2.0
+      duty_ema_minutes: 20
+      error_weight: 0.6
+      duty_weight: 0.4
+      slow_mix_weight: 0.8
+      fast_mix_weight: 0.2
+      fast_error_deadband_c: 0.4
+      fast_boost_gain: 1.2
+      fast_boost_cap_c: 1.2
+      slew_up_c_per_5m: 0.3
+      slew_down_c_per_5m: 0.2
+      write_deadband_c: 0.3
+      write_min_interval_minutes: 10
+      preheat_enabled: false
+      preheat_forecast_sensor: sensor.outdoor_forecast_2h
+      preheat_solar_sensor: sensor.solar_irradiance_forecast_2h
+      preheat_gain: 0.35
+      preheat_solar_gain_per_w_m2: 0.0
+      preheat_cap_c: 1.2
+      preheat_min_slow_di: 0.25
   zones:
     living_room:
       circuits:
@@ -232,8 +236,10 @@ Use `pwm` for slow floor loops that overshoot with on/off control; keep `bang_ba
 
 ### Flow mode: simple vs Pro supervisor
 
-- `flow_mode: simple` (default, free): flow follows the highest active target plus weather compensation.
+- `flow_mode: simple` (free): flow follows the highest active target plus weather compensation.
 - `flow_mode: pro_supervisor` (Sponsor License): demand-weighted flow supervision with slow/fast zone balancing, asymmetric slew limiting, and optional preheat forecast + solar-gain compensation.
+
+If `flow_mode` is omitted, Thermozona auto-selects `pro_supervisor` when `pro.license_key` is valid, otherwise `simple`.
 
 Per-zone Pro metadata:
 
@@ -306,9 +312,10 @@ Then wire that sensor into Thermozona:
 ```yaml
 thermozona:
   flow_mode: pro_supervisor
-  pro_flow:
-    preheat_enabled: true
-    preheat_forecast_sensor: sensor.outdoor_forecast_2h
+  pro:
+    flow:
+      preheat_enabled: true
+      preheat_forecast_sensor: sensor.outdoor_forecast_2h
 ```
 
 Tuning tips 🔧:
@@ -365,11 +372,12 @@ Then reference this sensor in Thermozona:
 ```yaml
 thermozona:
   flow_mode: pro_supervisor
-  pro_flow:
-    preheat_enabled: true
-    preheat_forecast_sensor: sensor.outdoor_forecast_2h
-    preheat_solar_sensor: sensor.solar_irradiance_forecast_2h
-    preheat_solar_gain_per_w_m2: 0.002
+  pro:
+    flow:
+      preheat_enabled: true
+      preheat_forecast_sensor: sensor.outdoor_forecast_2h
+      preheat_solar_sensor: sensor.solar_irradiance_forecast_2h
+      preheat_solar_gain_per_w_m2: 0.002
 ```
 
 ## Connecting Your Heat Pump 🔌

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ thermozona:
       hysteresis: 0.2
       zone_response: slow    # Optional: slow (default) or fast
       zone_flow_weight: 1.0  # Optional: influence in Pro flow supervisor
+      zone_solar_weight: 1.6 # Optional: higher value = stronger solar softening impact for this zone
       control_mode: pwm        # Optional: bang_bang (free) or pwm (Sponsor License)
       pwm_cycle_time: 15       # Optional: 5-30 minutes (default 15)
       pwm_min_on_time: 3       # Optional: 1-10 minutes (default 3)
@@ -238,6 +239,7 @@ Per-zone Pro metadata:
 
 - `zone_response`: `slow` (default) or `fast`.
 - `zone_flow_weight`: weighting factor (default `1.0`) used by the Pro flow supervisor.
+- `zone_solar_weight`: solar-exposure weighting (default `1.0`) used to scale preheat softening from forecast irradiance.
 
 #### 🌤️ Accurate 2h Forecast for Preheat
 

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -87,7 +87,9 @@ thermozona:
     write_min_interval_minutes: 10
     preheat_enabled: false
     preheat_forecast_sensor: sensor.weather_outdoor_2h
+    preheat_solar_sensor: sensor.weather_solar_irradiance_2h
     preheat_gain: 0.35
+    preheat_solar_gain_per_w_m2: 0.0
     preheat_cap_c: 1.2
     preheat_min_slow_di: 0.25
   zones:

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -58,41 +58,19 @@ input_boolean:
 thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
   # flow_mode: simple  # Optional override; auto-selects pro_supervisor when pro.license_key is valid
-  heating_base_offset: 3.0
-  cooling_base_offset: 2.5
-  flow_curve_offset: 0.0  # Optional UI baseline; UI tweaks reset on reload
-  weather_slope_heat: 0.25
-  weather_slope_cool: 0.20
-  simple_flow:
-    write_deadband_c: 0.5
-    write_min_interval_minutes: 15
-  pro:  # Optional, only used with flow_mode: pro_supervisor and valid token
+  # heating_base_offset: 3.0
+  # weather_slope_heat: 0.25
+
+  # Optional Pro block.
+  # Keep it small here; see README for the full Pro tuning matrix.
+  pro:
     # license_key: eyJhbGciOi...<signed_pro_token>
     flow:
-      kp: 1.0
-      use_integral: false
-      ti_minutes: 180
-      i_max: 1.5
-      error_norm_max: 2.0
-      duty_ema_minutes: 20
-      error_weight: 0.6
-      duty_weight: 0.4
-      slow_mix_weight: 0.8
-      fast_mix_weight: 0.2
-      fast_error_deadband_c: 0.4
-      fast_boost_gain: 1.2
-      fast_boost_cap_c: 1.2
-      slew_up_c_per_5m: 0.3
-      slew_down_c_per_5m: 0.2
-      write_deadband_c: 0.3
-      write_min_interval_minutes: 10
-      preheat_enabled: false
-      preheat_forecast_sensor: sensor.weather_outdoor_2h
-      preheat_solar_sensor: sensor.weather_solar_irradiance_2h
-      preheat_gain: 0.35
-      preheat_solar_gain_per_w_m2: 0.0
-      preheat_cap_c: 1.2
-      preheat_min_slow_di: 0.25
+      # preheat_enabled: true
+      # preheat_forecast_sensor: sensor.outdoor_forecast_2h
+      # preheat_solar_sensor: sensor.solar_irradiance_forecast_2h
+      # preheat_solar_gain_per_w_m2: 0.002
+
   zones:
     woonkamer:
       circuits:
@@ -100,16 +78,16 @@ thermozona:
         - input_boolean.verdeler_1_groep_2
         - input_boolean.verdeler_1_groep_3
       temp_sensor: sensor.test_woonkamer_temperatuur
-      hysteresis: 0.2
-      zone_response: slow
-      zone_flow_weight: 1.0
-      zone_solar_weight: 1.4
+      # hysteresis: 0.2
+      # zone_response: slow
+      # zone_flow_weight: 1.0
+      # zone_solar_weight: 1.4
 
     keuken:
       circuits:
         - input_boolean.verdeler_1_groep_4
       temp_sensor: sensor.test_keuken_temperatuur
-      hysteresis: 0.25
-      zone_response: slow
-      zone_flow_weight: 1.0
-      zone_solar_weight: 0.2
+      # hysteresis: 0.25
+      # zone_response: slow
+      # zone_flow_weight: 1.0
+      # zone_solar_weight: 0.2

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -58,10 +58,38 @@ input_boolean:
 thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
   # license_key: eyJhbGciOi...<signed_pro_token>  # Optional: unlocks Pro features
-  # flow_mode: pro_supervisor  # Pro only; falls back to simple without valid license
+  flow_mode: simple
   heating_base_offset: 3.0
   cooling_base_offset: 2.5
   flow_curve_offset: 0.0  # Optional UI baseline; UI tweaks reset on reload
+  weather_slope_heat: 0.25
+  weather_slope_cool: 0.20
+  simple_flow:
+    write_deadband_c: 0.5
+    write_min_interval_minutes: 15
+  pro_flow:  # Optional, only used with flow_mode: pro_supervisor and valid license_key
+    kp: 1.0
+    use_integral: false
+    ti_minutes: 180
+    i_max: 1.5
+    error_norm_max: 2.0
+    duty_ema_minutes: 20
+    error_weight: 0.6
+    duty_weight: 0.4
+    slow_mix_weight: 0.8
+    fast_mix_weight: 0.2
+    fast_error_deadband_c: 0.4
+    fast_boost_gain: 1.2
+    fast_boost_cap_c: 1.2
+    slew_up_c_per_5m: 0.3
+    slew_down_c_per_5m: 0.2
+    write_deadband_c: 0.3
+    write_min_interval_minutes: 10
+    preheat_enabled: false
+    preheat_forecast_sensor: sensor.weather_outdoor_2h
+    preheat_gain: 0.35
+    preheat_cap_c: 1.2
+    preheat_min_slow_di: 0.25
   zones:
     woonkamer:
       circuits:
@@ -70,9 +98,13 @@ thermozona:
         - input_boolean.verdeler_1_groep_3
       temp_sensor: sensor.test_woonkamer_temperatuur
       hysteresis: 0.2
+      zone_response: slow
+      zone_flow_weight: 1.0
 
     keuken:
       circuits:
         - input_boolean.verdeler_1_groep_4
       temp_sensor: sensor.test_keuken_temperatuur
       hysteresis: 0.25
+      zone_response: slow
+      zone_flow_weight: 1.0

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -57,8 +57,7 @@ input_boolean:
 # Safety notice: Use at your own risk; ensure code-compliant installation/wiring. Authors/contributors are not liable for damage, injury, or fire.
 thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
-  # license_key: eyJhbGciOi...<signed_pro_token>  # Optional: unlocks Pro features
-  flow_mode: simple
+  # flow_mode: simple  # Optional override; auto-selects pro_supervisor when pro.license_key is valid
   heating_base_offset: 3.0
   cooling_base_offset: 2.5
   flow_curve_offset: 0.0  # Optional UI baseline; UI tweaks reset on reload
@@ -67,31 +66,33 @@ thermozona:
   simple_flow:
     write_deadband_c: 0.5
     write_min_interval_minutes: 15
-  pro_flow:  # Optional, only used with flow_mode: pro_supervisor and valid license_key
-    kp: 1.0
-    use_integral: false
-    ti_minutes: 180
-    i_max: 1.5
-    error_norm_max: 2.0
-    duty_ema_minutes: 20
-    error_weight: 0.6
-    duty_weight: 0.4
-    slow_mix_weight: 0.8
-    fast_mix_weight: 0.2
-    fast_error_deadband_c: 0.4
-    fast_boost_gain: 1.2
-    fast_boost_cap_c: 1.2
-    slew_up_c_per_5m: 0.3
-    slew_down_c_per_5m: 0.2
-    write_deadband_c: 0.3
-    write_min_interval_minutes: 10
-    preheat_enabled: false
-    preheat_forecast_sensor: sensor.weather_outdoor_2h
-    preheat_solar_sensor: sensor.weather_solar_irradiance_2h
-    preheat_gain: 0.35
-    preheat_solar_gain_per_w_m2: 0.0
-    preheat_cap_c: 1.2
-    preheat_min_slow_di: 0.25
+  pro:  # Optional, only used with flow_mode: pro_supervisor and valid token
+    # license_key: eyJhbGciOi...<signed_pro_token>
+    flow:
+      kp: 1.0
+      use_integral: false
+      ti_minutes: 180
+      i_max: 1.5
+      error_norm_max: 2.0
+      duty_ema_minutes: 20
+      error_weight: 0.6
+      duty_weight: 0.4
+      slow_mix_weight: 0.8
+      fast_mix_weight: 0.2
+      fast_error_deadband_c: 0.4
+      fast_boost_gain: 1.2
+      fast_boost_cap_c: 1.2
+      slew_up_c_per_5m: 0.3
+      slew_down_c_per_5m: 0.2
+      write_deadband_c: 0.3
+      write_min_interval_minutes: 10
+      preheat_enabled: false
+      preheat_forecast_sensor: sensor.weather_outdoor_2h
+      preheat_solar_sensor: sensor.weather_solar_irradiance_2h
+      preheat_gain: 0.35
+      preheat_solar_gain_per_w_m2: 0.0
+      preheat_cap_c: 1.2
+      preheat_min_slow_di: 0.25
   zones:
     woonkamer:
       circuits:

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -102,6 +102,7 @@ thermozona:
       hysteresis: 0.2
       zone_response: slow
       zone_flow_weight: 1.0
+      zone_solar_weight: 1.4
 
     keuken:
       circuits:
@@ -110,3 +111,4 @@ thermozona:
       hysteresis: 0.25
       zone_response: slow
       zone_flow_weight: 1.0
+      zone_solar_weight: 0.2

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -21,6 +21,33 @@ CONF_HEAT_PUMP_MODE = "heat_pump_mode"
 CONF_HEATING_BASE_OFFSET = "heating_base_offset"
 CONF_COOLING_BASE_OFFSET = "cooling_base_offset"
 CONF_FLOW_CURVE_OFFSET = "flow_curve_offset"
+CONF_FLOW_MODE = "flow_mode"
+CONF_WEATHER_SLOPE_HEAT = "weather_slope_heat"
+CONF_WEATHER_SLOPE_COOL = "weather_slope_cool"
+CONF_SIMPLE_FLOW = "simple_flow"
+CONF_PRO_FLOW = "pro_flow"
+CONF_WRITE_DEADBAND_C = "write_deadband_c"
+CONF_WRITE_MIN_INTERVAL_MINUTES = "write_min_interval_minutes"
+CONF_PRO_KP = "kp"
+CONF_PRO_USE_INTEGRAL = "use_integral"
+CONF_PRO_TI_MINUTES = "ti_minutes"
+CONF_PRO_I_MAX = "i_max"
+CONF_PRO_ERROR_NORM_MAX = "error_norm_max"
+CONF_PRO_DUTY_EMA_MINUTES = "duty_ema_minutes"
+CONF_PRO_ERROR_WEIGHT = "error_weight"
+CONF_PRO_DUTY_WEIGHT = "duty_weight"
+CONF_PRO_SLOW_MIX_WEIGHT = "slow_mix_weight"
+CONF_PRO_FAST_MIX_WEIGHT = "fast_mix_weight"
+CONF_PRO_FAST_ERROR_DEADBAND_C = "fast_error_deadband_c"
+CONF_PRO_FAST_BOOST_GAIN = "fast_boost_gain"
+CONF_PRO_FAST_BOOST_CAP_C = "fast_boost_cap_c"
+CONF_PRO_SLEW_UP_C_PER_5M = "slew_up_c_per_5m"
+CONF_PRO_SLEW_DOWN_C_PER_5M = "slew_down_c_per_5m"
+CONF_PRO_PREHEAT_ENABLED = "preheat_enabled"
+CONF_PRO_PREHEAT_FORECAST_SENSOR = "preheat_forecast_sensor"
+CONF_PRO_PREHEAT_GAIN = "preheat_gain"
+CONF_PRO_PREHEAT_CAP_C = "preheat_cap_c"
+CONF_PRO_PREHEAT_MIN_SLOW_DI = "preheat_min_slow_di"
 CONF_CONTROL_MODE = "control_mode"
 CONF_FLOW_MODE = "flow_mode"
 CONF_PWM_CYCLE_TIME = "pwm_cycle_time"
@@ -29,10 +56,16 @@ CONF_PWM_MIN_OFF_TIME = "pwm_min_off_time"
 CONF_PWM_KP = "pwm_kp"
 CONF_PWM_KI = "pwm_ki"
 CONF_PWM_ACTUATOR_DELAY = "pwm_actuator_delay"
+CONF_ZONE_RESPONSE = "zone_response"
+CONF_ZONE_FLOW_WEIGHT = "zone_flow_weight"
 CONF_LICENSE_KEY = "license_key"
 
 CONTROL_MODE_BANG_BANG = "bang_bang"
 CONTROL_MODE_PWM = "pwm"
+FLOW_MODE_SIMPLE = "simple"
+FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
+ZONE_RESPONSE_SLOW = "slow"
+ZONE_RESPONSE_FAST = "fast"
 
 FLOW_MODE_SIMPLE = "simple"
 FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
@@ -40,6 +73,35 @@ FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
 DEFAULT_FLOW_CURVE_OFFSET = 0.0
+DEFAULT_FLOW_MODE = FLOW_MODE_SIMPLE
+DEFAULT_WEATHER_SLOPE_HEAT = 0.25
+DEFAULT_WEATHER_SLOPE_COOL = 0.2
+DEFAULT_SIMPLE_WRITE_DEADBAND_C = 0.5
+DEFAULT_SIMPLE_WRITE_MIN_INTERVAL_MINUTES = 15
+DEFAULT_PRO_KP = 1.0
+DEFAULT_PRO_USE_INTEGRAL = False
+DEFAULT_PRO_TI_MINUTES = 180
+DEFAULT_PRO_I_MAX = 1.5
+DEFAULT_PRO_ERROR_NORM_MAX = 2.0
+DEFAULT_PRO_DUTY_EMA_MINUTES = 20
+DEFAULT_PRO_ERROR_WEIGHT = 0.6
+DEFAULT_PRO_DUTY_WEIGHT = 0.4
+DEFAULT_PRO_SLOW_MIX_WEIGHT = 0.8
+DEFAULT_PRO_FAST_MIX_WEIGHT = 0.2
+DEFAULT_PRO_FAST_ERROR_DEADBAND_C = 0.4
+DEFAULT_PRO_FAST_BOOST_GAIN = 1.2
+DEFAULT_PRO_FAST_BOOST_CAP_C = 1.2
+DEFAULT_PRO_SLEW_UP_C_PER_5M = 0.3
+DEFAULT_PRO_SLEW_DOWN_C_PER_5M = 0.2
+DEFAULT_PRO_WRITE_DEADBAND_C = 0.3
+DEFAULT_PRO_WRITE_MIN_INTERVAL_MINUTES = 10
+DEFAULT_PRO_PREHEAT_ENABLED = False
+DEFAULT_PRO_PREHEAT_FORECAST_SENSOR = None
+DEFAULT_PRO_PREHEAT_GAIN = 0.35
+DEFAULT_PRO_PREHEAT_CAP_C = 1.2
+DEFAULT_PRO_PREHEAT_MIN_SLOW_DI = 0.25
+DEFAULT_ZONE_RESPONSE = ZONE_RESPONSE_SLOW
+DEFAULT_ZONE_FLOW_WEIGHT = 1.0
 CONF_HYSTERESIS = "hysteresis"
 
 DEFAULT_CONTROL_MODE = CONTROL_MODE_BANG_BANG
@@ -50,6 +112,112 @@ DEFAULT_PWM_KP = 30.0
 DEFAULT_PWM_KI = 2.0
 DEFAULT_PWM_ACTUATOR_DELAY = 3
 
+SIMPLE_FLOW_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            CONF_WRITE_DEADBAND_C,
+            default=DEFAULT_SIMPLE_WRITE_DEADBAND_C,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=5)),
+        vol.Optional(
+            CONF_WRITE_MIN_INTERVAL_MINUTES,
+            default=DEFAULT_SIMPLE_WRITE_MIN_INTERVAL_MINUTES,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=120)),
+    }
+)
+
+PRO_FLOW_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            CONF_PRO_KP,
+            default=DEFAULT_PRO_KP,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_USE_INTEGRAL,
+            default=DEFAULT_PRO_USE_INTEGRAL,
+        ): vol.In([True, False]),
+        vol.Optional(
+            CONF_PRO_TI_MINUTES,
+            default=DEFAULT_PRO_TI_MINUTES,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+        vol.Optional(
+            CONF_PRO_I_MAX,
+            default=DEFAULT_PRO_I_MAX,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_ERROR_NORM_MAX,
+            default=DEFAULT_PRO_ERROR_NORM_MAX,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=20)),
+        vol.Optional(
+            CONF_PRO_DUTY_EMA_MINUTES,
+            default=DEFAULT_PRO_DUTY_EMA_MINUTES,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=360)),
+        vol.Optional(
+            CONF_PRO_ERROR_WEIGHT,
+            default=DEFAULT_PRO_ERROR_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+        vol.Optional(
+            CONF_PRO_DUTY_WEIGHT,
+            default=DEFAULT_PRO_DUTY_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+        vol.Optional(
+            CONF_PRO_SLOW_MIX_WEIGHT,
+            default=DEFAULT_PRO_SLOW_MIX_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+        vol.Optional(
+            CONF_PRO_FAST_MIX_WEIGHT,
+            default=DEFAULT_PRO_FAST_MIX_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+        vol.Optional(
+            CONF_PRO_FAST_ERROR_DEADBAND_C,
+            default=DEFAULT_PRO_FAST_ERROR_DEADBAND_C,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=5)),
+        vol.Optional(
+            CONF_PRO_FAST_BOOST_GAIN,
+            default=DEFAULT_PRO_FAST_BOOST_GAIN,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_FAST_BOOST_CAP_C,
+            default=DEFAULT_PRO_FAST_BOOST_CAP_C,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_SLEW_UP_C_PER_5M,
+            default=DEFAULT_PRO_SLEW_UP_C_PER_5M,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_SLEW_DOWN_C_PER_5M,
+            default=DEFAULT_PRO_SLEW_DOWN_C_PER_5M,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_WRITE_DEADBAND_C,
+            default=DEFAULT_PRO_WRITE_DEADBAND_C,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=5)),
+        vol.Optional(
+            CONF_WRITE_MIN_INTERVAL_MINUTES,
+            default=DEFAULT_PRO_WRITE_MIN_INTERVAL_MINUTES,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=120)),
+        vol.Optional(
+            CONF_PRO_PREHEAT_ENABLED,
+            default=DEFAULT_PRO_PREHEAT_ENABLED,
+        ): vol.In([True, False]),
+        vol.Optional(
+            CONF_PRO_PREHEAT_FORECAST_SENSOR,
+            default=DEFAULT_PRO_PREHEAT_FORECAST_SENSOR,
+        ): vol.Any(None, cv.entity_id),
+        vol.Optional(
+            CONF_PRO_PREHEAT_GAIN,
+            default=DEFAULT_PRO_PREHEAT_GAIN,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_PREHEAT_CAP_C,
+            default=DEFAULT_PRO_PREHEAT_CAP_C,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_PREHEAT_MIN_SLOW_DI,
+            default=DEFAULT_PRO_PREHEAT_MIN_SLOW_DI,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
+    }
+)
+
 ZONE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CIRCUITS): [cv.entity_id],
@@ -58,6 +226,14 @@ ZONE_SCHEMA = vol.Schema(
             vol.Coerce(float),
             vol.Range(min=0, max=5),
         ),
+        vol.Optional(
+            CONF_ZONE_RESPONSE,
+            default=DEFAULT_ZONE_RESPONSE,
+        ): vol.In([ZONE_RESPONSE_SLOW, ZONE_RESPONSE_FAST]),
+        vol.Optional(
+            CONF_ZONE_FLOW_WEIGHT,
+            default=DEFAULT_ZONE_FLOW_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=2)),
         vol.Optional(
             CONF_CONTROL_MODE,
             default=DEFAULT_CONTROL_MODE,
@@ -108,8 +284,24 @@ CONFIG_SCHEMA = vol.Schema({
         ): vol.Coerce(float),
         vol.Optional(
             CONF_FLOW_MODE,
-            default=FLOW_MODE_SIMPLE,
+            default=DEFAULT_FLOW_MODE,
         ): vol.In([FLOW_MODE_SIMPLE, FLOW_MODE_PRO_SUPERVISOR]),
+        vol.Optional(
+            CONF_WEATHER_SLOPE_HEAT,
+            default=DEFAULT_WEATHER_SLOPE_HEAT,
+        ): vol.Coerce(float),
+        vol.Optional(
+            CONF_WEATHER_SLOPE_COOL,
+            default=DEFAULT_WEATHER_SLOPE_COOL,
+        ): vol.Coerce(float),
+        vol.Optional(
+            CONF_SIMPLE_FLOW,
+            default={},
+        ): SIMPLE_FLOW_SCHEMA,
+        vol.Optional(
+            CONF_PRO_FLOW,
+            default={},
+        ): PRO_FLOW_SCHEMA,
         vol.Optional(CONF_LICENSE_KEY): cv.string,
         vol.Required(CONF_ZONES): {
             cv.string: ZONE_SCHEMA

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -45,7 +45,9 @@ CONF_PRO_SLEW_UP_C_PER_5M = "slew_up_c_per_5m"
 CONF_PRO_SLEW_DOWN_C_PER_5M = "slew_down_c_per_5m"
 CONF_PRO_PREHEAT_ENABLED = "preheat_enabled"
 CONF_PRO_PREHEAT_FORECAST_SENSOR = "preheat_forecast_sensor"
+CONF_PRO_PREHEAT_SOLAR_SENSOR = "preheat_solar_sensor"
 CONF_PRO_PREHEAT_GAIN = "preheat_gain"
+CONF_PRO_PREHEAT_SOLAR_GAIN_PER_W_M2 = "preheat_solar_gain_per_w_m2"
 CONF_PRO_PREHEAT_CAP_C = "preheat_cap_c"
 CONF_PRO_PREHEAT_MIN_SLOW_DI = "preheat_min_slow_di"
 CONF_CONTROL_MODE = "control_mode"
@@ -97,7 +99,9 @@ DEFAULT_PRO_WRITE_DEADBAND_C = 0.3
 DEFAULT_PRO_WRITE_MIN_INTERVAL_MINUTES = 10
 DEFAULT_PRO_PREHEAT_ENABLED = False
 DEFAULT_PRO_PREHEAT_FORECAST_SENSOR = None
+DEFAULT_PRO_PREHEAT_SOLAR_SENSOR = None
 DEFAULT_PRO_PREHEAT_GAIN = 0.35
+DEFAULT_PRO_PREHEAT_SOLAR_GAIN_PER_W_M2 = 0.0
 DEFAULT_PRO_PREHEAT_CAP_C = 1.2
 DEFAULT_PRO_PREHEAT_MIN_SLOW_DI = 0.25
 DEFAULT_ZONE_RESPONSE = ZONE_RESPONSE_SLOW
@@ -204,9 +208,17 @@ PRO_FLOW_SCHEMA = vol.Schema(
             default=DEFAULT_PRO_PREHEAT_FORECAST_SENSOR,
         ): vol.Any(None, cv.entity_id),
         vol.Optional(
+            CONF_PRO_PREHEAT_SOLAR_SENSOR,
+            default=DEFAULT_PRO_PREHEAT_SOLAR_SENSOR,
+        ): vol.Any(None, cv.entity_id),
+        vol.Optional(
             CONF_PRO_PREHEAT_GAIN,
             default=DEFAULT_PRO_PREHEAT_GAIN,
         ): vol.All(vol.Coerce(float), vol.Range(min=0, max=20)),
+        vol.Optional(
+            CONF_PRO_PREHEAT_SOLAR_GAIN_PER_W_M2,
+            default=DEFAULT_PRO_PREHEAT_SOLAR_GAIN_PER_W_M2,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
         vol.Optional(
             CONF_PRO_PREHEAT_CAP_C,
             default=DEFAULT_PRO_PREHEAT_CAP_C,

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -25,7 +25,8 @@ CONF_FLOW_MODE = "flow_mode"
 CONF_WEATHER_SLOPE_HEAT = "weather_slope_heat"
 CONF_WEATHER_SLOPE_COOL = "weather_slope_cool"
 CONF_SIMPLE_FLOW = "simple_flow"
-CONF_PRO_FLOW = "pro_flow"
+CONF_PRO = "pro"
+CONF_PRO_FLOW = "flow"
 CONF_WRITE_DEADBAND_C = "write_deadband_c"
 CONF_WRITE_MIN_INTERVAL_MINUTES = "write_min_interval_minutes"
 CONF_PRO_KP = "kp"
@@ -51,7 +52,6 @@ CONF_PRO_PREHEAT_SOLAR_GAIN_PER_W_M2 = "preheat_solar_gain_per_w_m2"
 CONF_PRO_PREHEAT_CAP_C = "preheat_cap_c"
 CONF_PRO_PREHEAT_MIN_SLOW_DI = "preheat_min_slow_di"
 CONF_CONTROL_MODE = "control_mode"
-CONF_FLOW_MODE = "flow_mode"
 CONF_PWM_CYCLE_TIME = "pwm_cycle_time"
 CONF_PWM_MIN_ON_TIME = "pwm_min_on_time"
 CONF_PWM_MIN_OFF_TIME = "pwm_min_off_time"
@@ -69,9 +69,6 @@ FLOW_MODE_SIMPLE = "simple"
 FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
 ZONE_RESPONSE_SLOW = "slow"
 ZONE_RESPONSE_FAST = "fast"
-
-FLOW_MODE_SIMPLE = "simple"
-FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
 
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
@@ -232,6 +229,16 @@ PRO_FLOW_SCHEMA = vol.Schema(
     }
 )
 
+PRO_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_LICENSE_KEY): cv.string,
+        vol.Optional(
+            CONF_PRO_FLOW,
+            default={},
+        ): PRO_FLOW_SCHEMA,
+    }
+)
+
 ZONE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CIRCUITS): [cv.entity_id],
@@ -302,7 +309,6 @@ CONFIG_SCHEMA = vol.Schema({
         ): vol.Coerce(float),
         vol.Optional(
             CONF_FLOW_MODE,
-            default=DEFAULT_FLOW_MODE,
         ): vol.In([FLOW_MODE_SIMPLE, FLOW_MODE_PRO_SUPERVISOR]),
         vol.Optional(
             CONF_WEATHER_SLOPE_HEAT,
@@ -317,10 +323,9 @@ CONFIG_SCHEMA = vol.Schema({
             default={},
         ): SIMPLE_FLOW_SCHEMA,
         vol.Optional(
-            CONF_PRO_FLOW,
+            CONF_PRO,
             default={},
-        ): PRO_FLOW_SCHEMA,
-        vol.Optional(CONF_LICENSE_KEY): cv.string,
+        ): PRO_SCHEMA,
         vol.Required(CONF_ZONES): {
             cv.string: ZONE_SCHEMA
         }

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -60,6 +60,7 @@ CONF_PWM_KI = "pwm_ki"
 CONF_PWM_ACTUATOR_DELAY = "pwm_actuator_delay"
 CONF_ZONE_RESPONSE = "zone_response"
 CONF_ZONE_FLOW_WEIGHT = "zone_flow_weight"
+CONF_ZONE_SOLAR_WEIGHT = "zone_solar_weight"
 CONF_LICENSE_KEY = "license_key"
 
 CONTROL_MODE_BANG_BANG = "bang_bang"
@@ -106,6 +107,7 @@ DEFAULT_PRO_PREHEAT_CAP_C = 1.2
 DEFAULT_PRO_PREHEAT_MIN_SLOW_DI = 0.25
 DEFAULT_ZONE_RESPONSE = ZONE_RESPONSE_SLOW
 DEFAULT_ZONE_FLOW_WEIGHT = 1.0
+DEFAULT_ZONE_SOLAR_WEIGHT = 1.0
 CONF_HYSTERESIS = "hysteresis"
 
 DEFAULT_CONTROL_MODE = CONTROL_MODE_BANG_BANG
@@ -245,6 +247,10 @@ ZONE_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_ZONE_FLOW_WEIGHT,
             default=DEFAULT_ZONE_FLOW_WEIGHT,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0, max=2)),
+        vol.Optional(
+            CONF_ZONE_SOLAR_WEIGHT,
+            default=DEFAULT_ZONE_SOLAR_WEIGHT,
         ): vol.All(vol.Coerce(float), vol.Range(min=0, max=2)),
         vol.Optional(
             CONF_CONTROL_MODE,

--- a/custom_components/thermozona/climate.py
+++ b/custom_components/thermozona/climate.py
@@ -17,6 +17,7 @@ from . import (
     CONF_TEMP_SENSOR,
     CONF_ZONE_FLOW_WEIGHT,
     CONF_ZONE_RESPONSE,
+    CONF_ZONE_SOLAR_WEIGHT,
     DOMAIN,
 )
 from .heat_pump import HeatPumpController
@@ -75,6 +76,7 @@ async def async_setup_entry(
                 config.get(CONF_PWM_ACTUATOR_DELAY),
                 config.get(CONF_ZONE_RESPONSE),
                 config.get(CONF_ZONE_FLOW_WEIGHT),
+                config.get(CONF_ZONE_SOLAR_WEIGHT),
             )
         )
 

--- a/custom_components/thermozona/climate.py
+++ b/custom_components/thermozona/climate.py
@@ -15,6 +15,8 @@ from . import (
     CONF_PWM_MIN_OFF_TIME,
     CONF_PWM_MIN_ON_TIME,
     CONF_TEMP_SENSOR,
+    CONF_ZONE_FLOW_WEIGHT,
+    CONF_ZONE_RESPONSE,
     DOMAIN,
 )
 from .heat_pump import HeatPumpController
@@ -46,7 +48,11 @@ async def async_setup_entry(
 
     entities: list[ThermozonaThermostat] = []
     for zone_name, config in zones.items():
-        _LOGGER.debug("Creating thermostat for zone: %s with config: %s", zone_name, config)
+        _LOGGER.debug(
+            "Creating thermostat for zone: %s with config: %s",
+            zone_name,
+            config,
+        )
         circuits = resolve_circuits(config)
         if not circuits:
             _LOGGER.error("%s: No circuits defined for zone %s", DOMAIN, zone_name)
@@ -67,6 +73,8 @@ async def async_setup_entry(
                 config.get(CONF_PWM_KP),
                 config.get(CONF_PWM_KI),
                 config.get(CONF_PWM_ACTUATOR_DELAY),
+                config.get(CONF_ZONE_RESPONSE),
+                config.get(CONF_ZONE_FLOW_WEIGHT),
             )
         )
 

--- a/custom_components/thermozona/heat_pump.py
+++ b/custom_components/thermozona/heat_pump.py
@@ -18,11 +18,25 @@ from . import (
     CONF_LICENSE_KEY,
     CONF_COOLING_BASE_OFFSET,
     CONF_HEATING_BASE_OFFSET,
+    CONF_PRO_FLOW,
+    CONF_PRO_PREHEAT_ENABLED,
+    CONF_PRO_PREHEAT_FORECAST_SENSOR,
+    CONF_SIMPLE_FLOW,
     CONF_OUTSIDE_TEMP_SENSOR,
+    CONF_WEATHER_SLOPE_COOL,
+    CONF_WEATHER_SLOPE_HEAT,
+    CONF_WRITE_DEADBAND_C,
+    CONF_WRITE_MIN_INTERVAL_MINUTES,
     CONF_ZONES,
     DEFAULT_COOLING_BASE_OFFSET,
     DEFAULT_FLOW_CURVE_OFFSET,
     DEFAULT_HEATING_BASE_OFFSET,
+    DEFAULT_PRO_WRITE_DEADBAND_C,
+    DEFAULT_PRO_WRITE_MIN_INTERVAL_MINUTES,
+    DEFAULT_SIMPLE_WRITE_DEADBAND_C,
+    DEFAULT_SIMPLE_WRITE_MIN_INTERVAL_MINUTES,
+    DEFAULT_WEATHER_SLOPE_COOL,
+    DEFAULT_WEATHER_SLOPE_HEAT,
     DOMAIN,
     FLOW_MODE_PRO_SUPERVISOR,
     FLOW_MODE_SIMPLE,
@@ -32,6 +46,7 @@ from .licensing import LicenseValidationResult
 from .licensing import normalize_license_key
 from .licensing import validate_pro_license_key
 from .pro.flow_curve import FlowCurveRuntimeManager
+from .pro.flow_supervisor import ProFlowSupervisor
 
 if TYPE_CHECKING:
     from .thermostat import ThermozonaThermostat
@@ -51,7 +66,7 @@ class HeatPumpController:
     def __init__(self, hass: HomeAssistant, entry_config: dict[str, Any]) -> None:
         self._hass = hass
         self._entry_config = entry_config
-        self._zone_status: dict[str, dict[str, float]] = {}
+        self._zone_status: dict[str, dict[str, Any]] = {}
         self._last_auto_mode: HVACMode = HVACMode.HEAT
         self._thermostats: weakref.WeakSet[ThermozonaThermostat] = weakref.WeakSet()
         self._pwm_zone_indices: weakref.WeakKeyDictionary[ThermozonaThermostat, int] = weakref.WeakKeyDictionary()
@@ -66,6 +81,8 @@ class HeatPumpController:
             ThermozonaHeatPumpStatusSensor
         ] | None = None
         self._last_flow_temp: float | None = None
+        self._last_flow_write_temp: float | None = None
+        self._last_flow_write_time: datetime | None = None
         self._mode_select: weakref.ReferenceType[
             ThermozonaHeatPumpModeSelect
         ] | None = None
@@ -87,6 +104,7 @@ class HeatPumpController:
             get_yaml_value=self._get_yaml_flow_curve_offset,
             notify_thermostats=lambda: self._notify_thermostats(),
         )
+        self._pro_flow_supervisor = ProFlowSupervisor()
 
     @property
     def pro_enabled(self) -> bool:
@@ -133,6 +151,46 @@ class HeatPumpController:
             requested_flow_mode = FLOW_MODE_SIMPLE
 
         self._flow_mode = requested_flow_mode
+
+    def _get_flow_write_settings(self) -> tuple[float, timedelta]:
+        """Return deadband and minimum write interval for flow commands."""
+        if self.flow_mode == FLOW_MODE_PRO_SUPERVISOR:
+            config = self._entry_config.get(CONF_PRO_FLOW, {})
+            deadband_default = DEFAULT_PRO_WRITE_DEADBAND_C
+            min_interval_default = DEFAULT_PRO_WRITE_MIN_INTERVAL_MINUTES
+        else:
+            config = self._entry_config.get(CONF_SIMPLE_FLOW, {})
+            deadband_default = DEFAULT_SIMPLE_WRITE_DEADBAND_C
+            min_interval_default = DEFAULT_SIMPLE_WRITE_MIN_INTERVAL_MINUTES
+
+        deadband = max(
+            0.0,
+            float(config.get(CONF_WRITE_DEADBAND_C, deadband_default)),
+        )
+        min_interval_minutes = max(
+            1,
+            int(config.get(CONF_WRITE_MIN_INTERVAL_MINUTES, min_interval_default)),
+        )
+        return deadband, timedelta(minutes=min_interval_minutes)
+
+    def _should_dispatch_flow_temperature(
+        self,
+        *,
+        flow_temp: float,
+        now: datetime,
+    ) -> bool:
+        """Return True when a new flow command should be sent to output."""
+        if self._last_flow_write_temp is None or self._last_flow_write_time is None:
+            return True
+
+        deadband, min_interval = self._get_flow_write_settings()
+        if abs(flow_temp - self._last_flow_write_temp) >= deadband:
+            return True
+
+        if now - self._last_flow_write_time >= min_interval:
+            return True
+
+        return False
 
 
     def _outside_temp_sensor(self) -> str | None:
@@ -368,6 +426,9 @@ class HeatPumpController:
         target: float | None,
         current: float | None,
         active: bool | None = None,
+        duty_cycle: float | None = None,
+        zone_response: str | None = None,
+        zone_flow_weight: float | None = None,
         source: ThermozonaThermostat | None = None,
     ) -> None:
         """Store latest temperature/target info for the zone."""
@@ -379,6 +440,14 @@ class HeatPumpController:
             entry["current"] = float(current)
             if active is not None:
                 entry["active"] = bool(active)
+            if duty_cycle is not None:
+                entry["duty_cycle"] = max(0.0, min(100.0, float(duty_cycle)))
+            elif active is not None and "duty_cycle" not in entry:
+                entry["duty_cycle"] = 100.0 if active else 0.0
+            if zone_response is not None:
+                entry["zone_response"] = str(zone_response).lower()
+            if zone_flow_weight is not None:
+                entry["zone_flow_weight"] = max(0.0, float(zone_flow_weight))
 
         if active is not None and zone_name in self._zone_status:
             self._zone_status[zone_name]["active"] = bool(active)
@@ -419,52 +488,145 @@ class HeatPumpController:
 
         return self._last_auto_mode
 
-    def determine_flow_temperature(
-        self, effective_mode: HVACMode, outside_temp: float | None
+    def _relevant_statuses(self) -> list[dict[str, Any]]:
+        """Return active zone statuses, or all zones when none are active."""
+        active_statuses = [
+            status for status in self._zone_status.values() if status.get("active")
+        ]
+        return active_statuses or list(self._zone_status.values())
+
+    def _forecast_outside_temp(self) -> float | None:
+        """Return forecasted outside temperature used by optional preheat boost."""
+        pro_flow_config = self._entry_config.get(CONF_PRO_FLOW, {})
+        if not bool(pro_flow_config.get(CONF_PRO_PREHEAT_ENABLED, False)):
+            return None
+
+        forecast_sensor = pro_flow_config.get(CONF_PRO_PREHEAT_FORECAST_SENSOR)
+        if not forecast_sensor:
+            return None
+
+        forecast_state = self._hass.states.get(forecast_sensor)
+        if not forecast_state:
+            _LOGGER.debug(
+                "%s: Forecast sensor %s not found, skipping preheat",
+                DOMAIN,
+                forecast_sensor,
+            )
+            return None
+
+        try:
+            return float(forecast_state.state)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "%s: Invalid forecast temperature value from %s: %s",
+                DOMAIN,
+                forecast_sensor,
+                forecast_state.state,
+            )
+            return None
+
+    def _determine_simple_flow_temperature(
+        self,
+        *,
+        effective_mode: HVACMode,
+        outside_temp: float | None,
+        statuses: list[dict[str, Any]],
     ) -> float:
-        """Return desired flow temperature based on zone targets and weather."""
-
-        def _relevant_statuses() -> list[dict[str, float]]:
-            active_statuses = [
-                status for status in self._zone_status.values() if status.get("active")
-            ]
-            return active_statuses or list(self._zone_status.values())
-
-        statuses = _relevant_statuses()
-        if not statuses:
-            # Fall back to a safe low-temperature value when no zones are known
-            return 30.0 if effective_mode != HVACMode.COOL else 20.0
-
-        max_target = max(status["target"] for status in statuses)
-        min_target = min(status["target"] for status in statuses)
+        """Return simple free-tier flow strategy based on zone targets and weather."""
+        max_target = max(float(status["target"]) for status in statuses)
+        min_target = min(float(status["target"]) for status in statuses)
 
         if effective_mode == HVACMode.COOL:
-            min_temp = 15.0
-            max_temp = 25.0
             base_offset = float(
                 self._entry_config.get(
-                    CONF_COOLING_BASE_OFFSET, DEFAULT_COOLING_BASE_OFFSET
+                    CONF_COOLING_BASE_OFFSET,
+                    DEFAULT_COOLING_BASE_OFFSET,
+                )
+            )
+            slope = float(
+                self._entry_config.get(
+                    CONF_WEATHER_SLOPE_COOL,
+                    DEFAULT_WEATHER_SLOPE_COOL,
                 )
             )
             if outside_temp is not None:
-                base_offset += max(0.0, outside_temp - 24.0) * 0.2
-            base_offset += self.get_flow_curve_offset()
-            flow = min_target - base_offset
-            return max(min_temp, min(max_temp, flow))
+                base_offset += max(0.0, outside_temp - 24.0) * max(0.0, slope)
+            flow = min_target - base_offset - self.get_flow_curve_offset()
+            return max(15.0, min(25.0, flow))
 
-        # Heating branch (default)
-        min_temp = 15.0
-        max_temp = 35.0
         base_offset = float(
             self._entry_config.get(
-                CONF_HEATING_BASE_OFFSET, DEFAULT_HEATING_BASE_OFFSET
+                CONF_HEATING_BASE_OFFSET,
+                DEFAULT_HEATING_BASE_OFFSET,
+            )
+        )
+        slope = float(
+            self._entry_config.get(
+                CONF_WEATHER_SLOPE_HEAT,
+                DEFAULT_WEATHER_SLOPE_HEAT,
             )
         )
         if outside_temp is not None:
-            base_offset += max(0.0, 15.0 - outside_temp) * 0.25
-        base_offset += self.get_flow_curve_offset()
-        flow = max_target + base_offset
-        return max(min_temp, min(max_temp, flow))
+            base_offset += max(0.0, 15.0 - outside_temp) * max(0.0, slope)
+        flow = max_target + base_offset + self.get_flow_curve_offset()
+        return max(15.0, min(35.0, flow))
+
+    def _determine_pro_heating_flow_temperature(
+        self,
+        *,
+        outside_temp: float | None,
+    ) -> float:
+        """Return Pro flow strategy for heating with demand-weighted supervision."""
+        base_offset = float(
+            self._entry_config.get(
+                CONF_HEATING_BASE_OFFSET,
+                DEFAULT_HEATING_BASE_OFFSET,
+            )
+        )
+        weather_slope = float(
+            self._entry_config.get(
+                CONF_WEATHER_SLOPE_HEAT,
+                DEFAULT_WEATHER_SLOPE_HEAT,
+            )
+        )
+        pro_flow_config = self._entry_config.get(CONF_PRO_FLOW, {})
+        forecast_outside_temp = self._forecast_outside_temp()
+        flow = self._pro_flow_supervisor.compute_heating_flow(
+            zone_status=self._zone_status,
+            outside_temp=outside_temp,
+            forecast_outside_temp=forecast_outside_temp,
+            base_offset=base_offset,
+            weather_slope=weather_slope,
+            flow_curve_offset=self.get_flow_curve_offset(),
+            config=pro_flow_config,
+        )
+        return max(15.0, min(35.0, flow))
+
+    def determine_flow_temperature(
+        self, effective_mode: HVACMode, outside_temp: float | None
+    ) -> float:
+        """Return desired flow temperature based on active strategy."""
+        statuses = self._relevant_statuses()
+        if not statuses:
+            return 30.0 if effective_mode != HVACMode.COOL else 20.0
+
+        if effective_mode == HVACMode.COOL:
+            return self._determine_simple_flow_temperature(
+                effective_mode=effective_mode,
+                outside_temp=outside_temp,
+                statuses=statuses,
+            )
+
+        if self.flow_mode == FLOW_MODE_PRO_SUPERVISOR:
+            return self._determine_pro_heating_flow_temperature(
+                outside_temp=outside_temp,
+            )
+
+        return self._determine_simple_flow_temperature(
+            effective_mode=effective_mode,
+            outside_temp=outside_temp,
+            statuses=statuses,
+        )
 
     def register_thermostat(self, thermostat: ThermozonaThermostat) -> None:
         """Register a thermostat for notifications."""
@@ -590,12 +752,23 @@ class HeatPumpController:
         )
 
         self._last_flow_temp = flow_temp
+        now = datetime.now(timezone.utc)
 
         if (sensor_entity := self._flow_temp_sensor()) is not None:
             sensor_entity.set_calculated_value(flow_temp)
 
+        if not self._should_dispatch_flow_temperature(flow_temp=flow_temp, now=now):
+            _LOGGER.debug(
+                "%s: Suppressing flow setpoint write %.2f°C due to deadband/interval policy",
+                DOMAIN,
+                flow_temp,
+            )
+            return effective_mode
+
         if (number_entity := self._flow_temp_number()) is not None:
             number_entity.set_calculated_value(flow_temp)
+            self._last_flow_write_temp = flow_temp
+            self._last_flow_write_time = now
             return effective_mode
 
         if flow_temp_entity := self._flow_temp_entity():
@@ -605,6 +778,8 @@ class HeatPumpController:
                 {"entity_id": flow_temp_entity, "value": flow_temp},
                 blocking=True,
             )
+            self._last_flow_write_temp = flow_temp
+            self._last_flow_write_time = now
         return effective_mode
 
     def refresh_entry_config(self, entry_config: dict[str, Any]) -> None:
@@ -617,4 +792,7 @@ class HeatPumpController:
             license_result,
             entry_config.get(CONF_FLOW_MODE),
         )
+        self._pro_flow_supervisor.reset()
+        self._last_flow_write_temp = None
+        self._last_flow_write_time = None
         self.reset_flow_curve_offset()

--- a/custom_components/thermozona/heat_pump.py
+++ b/custom_components/thermozona/heat_pump.py
@@ -430,6 +430,7 @@ class HeatPumpController:
         duty_cycle: float | None = None,
         zone_response: str | None = None,
         zone_flow_weight: float | None = None,
+        zone_solar_weight: float | None = None,
         source: ThermozonaThermostat | None = None,
     ) -> None:
         """Store latest temperature/target info for the zone."""
@@ -449,6 +450,8 @@ class HeatPumpController:
                 entry["zone_response"] = str(zone_response).lower()
             if zone_flow_weight is not None:
                 entry["zone_flow_weight"] = max(0.0, float(zone_flow_weight))
+            if zone_solar_weight is not None:
+                entry["zone_solar_weight"] = max(0.0, float(zone_solar_weight))
 
         if active is not None and zone_name in self._zone_status:
             self._zone_status[zone_name]["active"] = bool(active)

--- a/custom_components/thermozona/pro/flow_supervisor.py
+++ b/custom_components/thermozona/pro/flow_supervisor.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: 2026 Jaap van der Meer
+# SPDX-License-Identifier: LicenseRef-Thermozona-Commercial
+"""Sponsor-required flow-temperature supervisor for heating mode."""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any, NamedTuple
+
+from .. import ZONE_RESPONSE_FAST, ZONE_RESPONSE_SLOW
+
+
+class _ZoneDemand(NamedTuple):
+    """Normalized per-zone demand contribution."""
+
+    zone_name: str
+    target: float
+    error: float
+    duty: float
+    response: str
+    weight: float
+    score: float
+
+
+class ProFlowSupervisor:
+    """Compute a stable, demand-weighted heating flow setpoint."""
+
+    def __init__(self) -> None:
+        self._ema_duty: dict[str, float] = {}
+        self._integral = 0.0
+        self._last_eval_time: datetime | None = None
+        self._last_flow = 30.0
+
+    def reset(self) -> None:
+        """Reset adaptive state after reload/reconfiguration."""
+        self._ema_duty.clear()
+        self._integral = 0.0
+        self._last_eval_time = None
+        self._last_flow = 30.0
+
+    def compute_heating_flow(
+        self,
+        *,
+        zone_status: dict[str, dict[str, Any]],
+        outside_temp: float | None,
+        forecast_outside_temp: float | None,
+        base_offset: float,
+        weather_slope: float,
+        flow_curve_offset: float,
+        config: dict[str, Any],
+    ) -> float:
+        """Return supervised heating flow command in degrees Celsius."""
+        now = datetime.now(timezone.utc)
+        dt_minutes = self._get_dt_minutes(now)
+
+        demand_entries = self._build_zone_demands(zone_status, dt_minutes, config)
+        if not demand_entries:
+            self._last_eval_time = now
+            return 30.0
+
+        slow_entries = [
+            entry for entry in demand_entries if entry.response == ZONE_RESPONSE_SLOW
+        ]
+        fast_entries = [
+            entry for entry in demand_entries if entry.response == ZONE_RESPONSE_FAST
+        ]
+        if not slow_entries:
+            slow_entries = demand_entries
+
+        target_ref = max(entry.target for entry in slow_entries)
+
+        di_slow = self._weighted_average(
+            [(entry.score, entry.weight) for entry in slow_entries]
+        )
+        di_fast = self._weighted_average(
+            [(entry.score, entry.weight) for entry in fast_entries]
+        )
+        if not fast_entries:
+            di_fast = di_slow
+
+        slow_mix = max(0.0, float(config.get("slow_mix_weight", 0.8)))
+        fast_mix = max(0.0, float(config.get("fast_mix_weight", 0.2)))
+        mix_total = slow_mix + fast_mix
+        if mix_total <= 0:
+            slow_mix = 1.0
+            fast_mix = 0.0
+            mix_total = 1.0
+        slow_mix /= mix_total
+        fast_mix /= mix_total
+        demand_index = (slow_mix * di_slow) + (fast_mix * di_fast)
+
+        weather_term = base_offset + flow_curve_offset
+        if outside_temp is not None:
+            weather_term += max(0.0, 15.0 - outside_temp) * max(0.0, weather_slope)
+        flow = target_ref + weather_term
+
+        kp = max(0.0, float(config.get("kp", 1.0)))
+        trim = kp * demand_index
+
+        use_integral = bool(config.get("use_integral", False))
+        if use_integral:
+            ti_minutes = max(1.0, float(config.get("ti_minutes", 180)))
+            i_max = max(0.0, float(config.get("i_max", 1.5)))
+            self._integral += demand_index * (dt_minutes / ti_minutes)
+            self._integral = self._clamp(self._integral, 0.0, i_max)
+            trim += self._integral
+        else:
+            self._integral = 0.0
+
+        fast_boost = self._compute_fast_zone_boost(
+            fast_entries=fast_entries,
+            error_deadband=float(config.get("fast_error_deadband_c", 0.4)),
+            gain=float(config.get("fast_boost_gain", 1.2)),
+            cap=float(config.get("fast_boost_cap_c", 1.2)),
+        )
+
+        preheat_boost = self._compute_preheat_boost(
+            enabled=bool(config.get("preheat_enabled", False)),
+            outside_temp=outside_temp,
+            forecast_outside_temp=forecast_outside_temp,
+            slow_di=di_slow,
+            gain=float(config.get("preheat_gain", 0.35)),
+            cap=float(config.get("preheat_cap_c", 1.2)),
+            min_slow_di=float(config.get("preheat_min_slow_di", 0.25)),
+        )
+
+        raw_flow = flow + trim + fast_boost + preheat_boost
+        smoothed_flow = self._apply_slew_rate(raw_flow=raw_flow, now=now, config=config)
+        self._last_eval_time = now
+        self._last_flow = smoothed_flow
+        return self._clamp(smoothed_flow, 15.0, 35.0)
+
+    def _build_zone_demands(
+        self,
+        zone_status: dict[str, dict[str, Any]],
+        dt_minutes: float,
+        config: dict[str, Any],
+    ) -> list[_ZoneDemand]:
+        error_norm_max = max(0.1, float(config.get("error_norm_max", 2.0)))
+        duty_ema_minutes = max(1.0, float(config.get("duty_ema_minutes", 20)))
+
+        error_weight = max(0.0, float(config.get("error_weight", 0.6)))
+        duty_weight = max(0.0, float(config.get("duty_weight", 0.4)))
+        weight_total = error_weight + duty_weight
+        if weight_total <= 0:
+            error_weight = 1.0
+            duty_weight = 0.0
+            weight_total = 1.0
+        error_weight /= weight_total
+        duty_weight /= weight_total
+
+        entries: list[_ZoneDemand] = []
+        for zone_name, status in zone_status.items():
+            target = status.get("target")
+            current = status.get("current")
+            if target is None or current is None:
+                continue
+
+            target_value = float(target)
+            current_value = float(current)
+            error = max(0.0, target_value - current_value)
+            normalized_error = self._clamp(error / error_norm_max, 0.0, 1.0)
+
+            raw_duty = self._clamp(float(status.get("duty_cycle", 0.0)), 0.0, 100.0)
+            filtered_duty = self._update_duty_ema(
+                zone_name=zone_name,
+                raw_duty=raw_duty,
+                dt_minutes=dt_minutes,
+                tau_minutes=duty_ema_minutes,
+            )
+            duty_fraction = filtered_duty / 100.0
+
+            response = str(status.get("zone_response", ZONE_RESPONSE_SLOW)).lower()
+            if response not in {ZONE_RESPONSE_SLOW, ZONE_RESPONSE_FAST}:
+                response = ZONE_RESPONSE_SLOW
+
+            zone_weight = max(0.0, float(status.get("zone_flow_weight", 1.0)))
+            score = (error_weight * normalized_error) + (duty_weight * duty_fraction)
+            entries.append(
+                _ZoneDemand(
+                    zone_name=zone_name,
+                    target=target_value,
+                    error=error,
+                    duty=duty_fraction,
+                    response=response,
+                    weight=zone_weight,
+                    score=score,
+                )
+            )
+
+        return entries
+
+    def _update_duty_ema(
+        self,
+        *,
+        zone_name: str,
+        raw_duty: float,
+        dt_minutes: float,
+        tau_minutes: float,
+    ) -> float:
+        previous = self._ema_duty.get(zone_name)
+        if previous is None:
+            self._ema_duty[zone_name] = raw_duty
+            return raw_duty
+
+        alpha = 1.0 - math.exp(-dt_minutes / max(tau_minutes, 1e-6))
+        filtered = previous + alpha * (raw_duty - previous)
+        self._ema_duty[zone_name] = filtered
+        return filtered
+
+    def _compute_fast_zone_boost(
+        self,
+        *,
+        fast_entries: list[_ZoneDemand],
+        error_deadband: float,
+        gain: float,
+        cap: float,
+    ) -> float:
+        if not fast_entries:
+            return 0.0
+
+        excess_values = []
+        deadband = max(0.0, error_deadband)
+        for entry in fast_entries:
+            excess_error = max(0.0, entry.error - deadband)
+            excess_values.append(excess_error * entry.duty * entry.weight)
+
+        if not excess_values:
+            return 0.0
+        raw_boost = max(excess_values) * max(0.0, gain)
+        return self._clamp(raw_boost, 0.0, max(0.0, cap))
+
+    def _compute_preheat_boost(
+        self,
+        *,
+        enabled: bool,
+        outside_temp: float | None,
+        forecast_outside_temp: float | None,
+        slow_di: float,
+        gain: float,
+        cap: float,
+        min_slow_di: float,
+    ) -> float:
+        if not enabled:
+            return 0.0
+        if outside_temp is None or forecast_outside_temp is None:
+            return 0.0
+        if slow_di < max(0.0, min_slow_di):
+            return 0.0
+
+        cold_drop = max(0.0, outside_temp - forecast_outside_temp)
+        preheat = cold_drop * max(0.0, gain)
+        return self._clamp(preheat, 0.0, max(0.0, cap))
+
+    def _apply_slew_rate(
+        self,
+        *,
+        raw_flow: float,
+        now: datetime,
+        config: dict[str, Any],
+    ) -> float:
+        if self._last_eval_time is None:
+            return raw_flow
+
+        dt_seconds = max(1.0, (now - self._last_eval_time).total_seconds())
+        slew_up_per_5m = max(0.0, float(config.get("slew_up_c_per_5m", 0.3)))
+        slew_down_per_5m = max(0.0, float(config.get("slew_down_c_per_5m", 0.2)))
+
+        max_up = (slew_up_per_5m / 300.0) * dt_seconds
+        max_down = (slew_down_per_5m / 300.0) * dt_seconds
+
+        lower = self._last_flow - max_down
+        upper = self._last_flow + max_up
+        return self._clamp(raw_flow, lower, upper)
+
+    def _get_dt_minutes(self, now: datetime) -> float:
+        if self._last_eval_time is None:
+            return 1.0
+        dt_seconds = max((now - self._last_eval_time).total_seconds(), 1.0)
+        return dt_seconds / 60.0
+
+    @staticmethod
+    def _weighted_average(values: list[tuple[float, float]]) -> float:
+        weighted_sum = 0.0
+        total_weight = 0.0
+        for value, weight in values:
+            if weight <= 0:
+                continue
+            weighted_sum += value * weight
+            total_weight += weight
+        if total_weight <= 0:
+            return 0.0
+        return weighted_sum / total_weight
+
+    @staticmethod
+    def _clamp(value: float, minimum: float, maximum: float) -> float:
+        return max(minimum, min(maximum, value))

--- a/custom_components/thermozona/thermostat.py
+++ b/custom_components/thermozona/thermostat.py
@@ -29,6 +29,8 @@ from . import (
     DEFAULT_PWM_KP,
     DEFAULT_PWM_MIN_OFF_TIME,
     DEFAULT_PWM_MIN_ON_TIME,
+    DEFAULT_ZONE_FLOW_WEIGHT,
+    DEFAULT_ZONE_RESPONSE,
     DOMAIN,
 )
 from .heat_pump import HeatPumpController
@@ -76,6 +78,8 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
         pwm_kp: float | None,
         pwm_ki: float | None,
         pwm_actuator_delay: int | None,
+        zone_response: str | None = None,
+        zone_flow_weight: float | None = None,
     ) -> None:
         """Initialize the thermostat."""
         self.hass = hass
@@ -125,6 +129,13 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
         )
         self._pwm_zone_index = 0
         self._pwm_zone_count = 0
+        self._zone_response = (zone_response or DEFAULT_ZONE_RESPONSE).lower()
+        self._zone_flow_weight = (
+            float(zone_flow_weight)
+            if zone_flow_weight is not None
+            else DEFAULT_ZONE_FLOW_WEIGHT
+        )
+        self._zone_flow_weight = max(0.0, self._zone_flow_weight)
 
         self._pwm_cycle_start: datetime | None = None
         self._pwm_on_time = timedelta()
@@ -228,6 +239,8 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             "pwm_actuator_delay": self._pwm_actuator_delay_minutes,
             "pwm_zone_index": self._pwm_zone_index,
             "pwm_zone_count": self._pwm_zone_count,
+            "zone_response": self._zone_response,
+            "zone_flow_weight": round(self._zone_flow_weight, 2),
             PWM_INTEGRAL_KEY: round(self._pwm_integral, 4),
         }
 
@@ -297,6 +310,9 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             target=self._attr_target_temperature,
             current=current_temp,
             active=active_before,
+            duty_cycle=self._current_zone_duty_hint(active_before),
+            zone_response=self._zone_response,
+            zone_flow_weight=self._zone_flow_weight,
             source=self,
         )
 
@@ -313,6 +329,9 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
                 target=self._attr_target_temperature,
                 current=current_temp,
                 active=False,
+                duty_cycle=0.0,
+                zone_response=self._zone_response,
+                zone_flow_weight=self._zone_flow_weight,
                 source=self,
             )
             self.async_write_ha_state()
@@ -330,9 +349,18 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             target=self._attr_target_temperature,
             current=current_temp,
             active=active_after,
+            duty_cycle=self._current_zone_duty_hint(active_after),
+            zone_response=self._zone_response,
+            zone_flow_weight=self._zone_flow_weight,
             source=self,
         )
         self.async_write_ha_state()
+
+    def _current_zone_duty_hint(self, is_active: bool) -> float:
+        """Return zone demand proxy for flow-supervisor calculations."""
+        if self._control_mode == CONTROL_MODE_PWM:
+            return max(0.0, min(100.0, float(self._pwm_duty_cycle)))
+        return 100.0 if is_active else 0.0
 
     def _resolve_effective_mode(self, pump_mode: str) -> HVACMode:
         """Map pump mode to a climate mode."""

--- a/custom_components/thermozona/thermostat.py
+++ b/custom_components/thermozona/thermostat.py
@@ -31,6 +31,7 @@ from . import (
     DEFAULT_PWM_MIN_ON_TIME,
     DEFAULT_ZONE_FLOW_WEIGHT,
     DEFAULT_ZONE_RESPONSE,
+    DEFAULT_ZONE_SOLAR_WEIGHT,
     DOMAIN,
 )
 from .heat_pump import HeatPumpController
@@ -80,6 +81,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
         pwm_actuator_delay: int | None,
         zone_response: str | None = None,
         zone_flow_weight: float | None = None,
+        zone_solar_weight: float | None = None,
     ) -> None:
         """Initialize the thermostat."""
         self.hass = hass
@@ -136,6 +138,12 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             else DEFAULT_ZONE_FLOW_WEIGHT
         )
         self._zone_flow_weight = max(0.0, self._zone_flow_weight)
+        self._zone_solar_weight = (
+            float(zone_solar_weight)
+            if zone_solar_weight is not None
+            else DEFAULT_ZONE_SOLAR_WEIGHT
+        )
+        self._zone_solar_weight = max(0.0, self._zone_solar_weight)
 
         self._pwm_cycle_start: datetime | None = None
         self._pwm_on_time = timedelta()
@@ -241,6 +249,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             "pwm_zone_count": self._pwm_zone_count,
             "zone_response": self._zone_response,
             "zone_flow_weight": round(self._zone_flow_weight, 2),
+            "zone_solar_weight": round(self._zone_solar_weight, 2),
             PWM_INTEGRAL_KEY: round(self._pwm_integral, 4),
         }
 
@@ -313,6 +322,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             duty_cycle=self._current_zone_duty_hint(active_before),
             zone_response=self._zone_response,
             zone_flow_weight=self._zone_flow_weight,
+            zone_solar_weight=self._zone_solar_weight,
             source=self,
         )
 
@@ -332,6 +342,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
                 duty_cycle=0.0,
                 zone_response=self._zone_response,
                 zone_flow_weight=self._zone_flow_weight,
+                zone_solar_weight=self._zone_solar_weight,
                 source=self,
             )
             self.async_write_ha_state()
@@ -352,6 +363,7 @@ class ThermozonaThermostat(ClimateEntity, RestoreEntity):
             duty_cycle=self._current_zone_duty_hint(active_after),
             zone_response=self._zone_response,
             zone_flow_weight=self._zone_flow_weight,
+            zone_solar_weight=self._zone_solar_weight,
             source=self,
         )
         self.async_write_ha_state()

--- a/tests/test_thermozona.py
+++ b/tests/test_thermozona.py
@@ -94,7 +94,18 @@ def _config(*, pro=True, **overrides):
         },
     }
     if pro:
-        base["license_key"] = _valid_sponsor_token()
+        base["pro"] = {"license_key": _valid_sponsor_token()}
+
+    if "pro_flow" in overrides:
+        pro_config = dict(base.get("pro", {}))
+        pro_config["flow"] = overrides.pop("pro_flow")
+        base["pro"] = pro_config
+
+    if "license_key" in overrides:
+        pro_config = dict(base.get("pro", {}))
+        pro_config["license_key"] = overrides.pop("license_key")
+        base["pro"] = pro_config
+
     base.update(overrides)
     return base
 
@@ -1011,6 +1022,15 @@ def test_valid_pro_license_allows_pro_supervisor_flow_mode(fake_hass):
     controller = HeatPumpController(
         fake_hass,
         _config(pro=True, flow_mode="pro_supervisor"),
+    )
+
+    assert controller.flow_mode == "pro_supervisor"
+
+
+def test_valid_pro_license_defaults_to_pro_supervisor_when_flow_mode_omitted(fake_hass):
+    controller = HeatPumpController(
+        fake_hass,
+        _config(pro=True),
     )
 
     assert controller.flow_mode == "pro_supervisor"

--- a/tests/test_thermozona.py
+++ b/tests/test_thermozona.py
@@ -486,6 +486,73 @@ def test_pro_preheat_boost_increases_flow_when_forecast_is_colder(fake_hass):
     assert flow_with_preheat > flow_without_preheat
 
 
+def test_pro_preheat_solar_forecast_softens_preheat_boost(fake_hass):
+    no_solar = HeatPumpController(
+        fake_hass,
+        _config(
+            flow_mode="pro_supervisor",
+            pro_flow={
+                "kp": 0.0,
+                "use_integral": False,
+                "fast_boost_gain": 0.0,
+                "preheat_enabled": True,
+                "preheat_forecast_sensor": "sensor.outside_forecast",
+                "preheat_gain": 0.35,
+                "preheat_cap_c": 1.2,
+                "preheat_min_slow_di": 0.0,
+                "slew_up_c_per_5m": 20.0,
+                "slew_down_c_per_5m": 20.0,
+            },
+        ),
+    )
+    with_solar = HeatPumpController(
+        fake_hass,
+        _config(
+            flow_mode="pro_supervisor",
+            pro_flow={
+                "kp": 0.0,
+                "use_integral": False,
+                "fast_boost_gain": 0.0,
+                "preheat_enabled": True,
+                "preheat_forecast_sensor": "sensor.outside_forecast",
+                "preheat_solar_sensor": "sensor.solar_forecast",
+                "preheat_gain": 0.35,
+                "preheat_solar_gain_per_w_m2": 0.002,
+                "preheat_cap_c": 1.2,
+                "preheat_min_slow_di": 0.0,
+                "slew_up_c_per_5m": 20.0,
+                "slew_down_c_per_5m": 20.0,
+            },
+        ),
+    )
+
+    fake_hass.states.set("sensor.outside", "8")
+    fake_hass.states.set("sensor.outside_forecast", "2")
+    fake_hass.states.set("sensor.solar_forecast", "500")
+
+    for controller in (no_solar, with_solar):
+        controller.update_zone_status(
+            "living",
+            target=21,
+            current=20,
+            active=True,
+            duty_cycle=20,
+            zone_response="slow",
+            zone_flow_weight=1.0,
+        )
+
+    flow_without_solar = no_solar.determine_flow_temperature(
+        HVACMode.HEAT,
+        outside_temp=8,
+    )
+    flow_with_solar = with_solar.determine_flow_temperature(
+        HVACMode.HEAT,
+        outside_temp=8,
+    )
+
+    assert flow_with_solar < flow_without_solar
+
+
 def test_pro_slew_rate_is_asymmetric(fake_hass):
     controller = HeatPumpController(
         fake_hass,


### PR DESCRIPTION
## Summary
- Add configurable `flow_mode` support with simple and Pro supervisor profiles, including schema/defaults for weather slopes, write deadband/interval, and zone-level response weighting.
- Introduce a Pro heating flow supervisor with demand indexing, duty EMA, fast-zone boost, optional forecast preheat, asymmetric slew limiting, and forecast solar softening.
- Add per-zone solar exposure weighting (`zone_solar_weight`) so irradiance softening can reflect room differences (for example kitchen vs bathroom) while still driving a single shared flow setpoint.
- Refactor Pro YAML into a dedicated block (`thermozona.pro`) with `pro.license_key` and `pro.flow.*` (no legacy top-level `license_key` / `pro_flow` support).
- Make `flow_mode` auto-select `pro_supervisor` when a valid Pro token is present and `flow_mode` is omitted; otherwise default to `simple`.
- Expand README/config examples with a production-ready corrected 2h outside forecast pattern, free `preheat_solar_sensor` source options, and token availability guidance (`https://github.com/sponsors/thermozona`; until live: `info@thermozona.com`).
- Simplify `configuration.yaml.example` to a minimal starter setup and move advanced Pro/zone knobs into concise commented hints.
- Extend tests for preheat/solar behavior including a per-zone solar-weight regression case and the new flow-mode default behavior.

## Testing
- `python3 -m compileall custom_components tests`
- `python -m pytest tests/test_thermozona.py -q` *(fails locally: No module named pytest)*