### PR TITLE
Harden Pro license JWT validation and add issuer tooling

### DIFF
--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -18,6 +18,8 @@ You may not:
 - sublicense, resell, or offer as a hosted service
 - remove licensing notices
 - share sponsor tokens publicly
+- tamper with or bypass licensing enforcement, including modifying verification logic,
+  replacing embedded/public verification keys, or disabling token checks
 
 ## 3. Tokens
 

--- a/NOTICE
+++ b/NOTICE
@@ -7,6 +7,9 @@ Unless otherwise stated, source files in this repository are licensed under the 
 Sponsor-required components are NOT licensed under MIT. These components are licensed under
 the Thermozona Commercial License (see LICENSE-COMMERCIAL.md).
 
+Under the commercial terms, tampering with Pro-license validation (including modifying
+verification keys or bypassing token checks) is not permitted.
+
 Sponsor-required files are identified by:
 1) a file-level header indicating "SPDX-License-Identifier: LicenseRef-Thermozona-Commercial", and/or
 2) placement in designated sponsor-required component paths documented in README.

--- a/README.md
+++ b/README.md
@@ -56,26 +56,19 @@ Thermozona is community-funded. The core integration stays open and free, while 
 ## Pro license generation
 
 Thermozona Pro tokens are signed with **Ed25519**. The integration ships with a public key and only accepts tokens signed by the matching private key.
+For full generation instructions, environment variable details, and examples, run:
 
-1. Store your issuer private key in an environment variable (never commit it):
+```bash
+python scripts/issue_pro_license.py --help
+```
 
-   ```bash
-   export THERMOZONA_LICENSE_PRIVATE_KEY_PEM="$(cat /secure/location/thermozona-license-private.pem)"
-   ```
+Optional local verification:
 
-2. Issue a token:
+```bash
+python scripts/verify_pro_license.py "<jwt-token>"
+```
 
-   ```bash
-   python scripts/issue_pro_license.py --sub github:japetheape --days 30 --issuer thermozona --source github_sponsors --tier pro --kid main-2026-01
-   ```
-
-3. (Optional) verify locally:
-
-   ```bash
-   python scripts/verify_pro_license.py "<jwt-token>"
-   ```
-
-4. Paste the token in `configuration.yaml`:
+Place the generated token in `configuration.yaml`:
 
    ```yaml
    thermozona:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Thermozona Pro tokens are signed with **Ed25519**. The integration ships with a 
 
 For key rotation, you can provide multiple public keys to Home Assistant via `THERMOZONA_LICENSE_PUBLIC_KEYS_JSON` as a JSON object (`{"kid":"-----BEGIN PUBLIC KEY-----..."}`), while issuer tokens set the matching `kid` header.
 
+### Key rotation runbook
+
+1. Generate a new Ed25519 key pair and store the private key in your password manager (for example KeePass).
+2. Add the new public key to `THERMOZONA_LICENSE_PUBLIC_KEYS_JSON` next to the current key (keep both active during migration).
+3. Start issuing new tokens with the new `--kid` value.
+4. Wait until old tokens naturally expire.
+5. Remove the old `kid` from `THERMOZONA_LICENSE_PUBLIC_KEYS_JSON`.
+
 ## Licensing transparency
 
 - Core/open components are licensed under MIT (`LICENSE`).

--- a/configuration.yaml.example
+++ b/configuration.yaml.example
@@ -57,7 +57,8 @@ input_boolean:
 # Safety notice: Use at your own risk; ensure code-compliant installation/wiring. Authors/contributors are not liable for damage, injury, or fire.
 thermozona:
   outside_temp_sensor: sensor.test_buiten_temperatuur
-  # license_key: eyJhbGciOi...<github_sponsor_token>  # Optional: unlocks Pro features
+  # license_key: eyJhbGciOi...<signed_pro_token>  # Optional: unlocks Pro features
+  # flow_mode: pro_supervisor  # Pro only; falls back to simple without valid license
   heating_base_offset: 3.0
   cooling_base_offset: 2.5
   flow_curve_offset: 0.0  # Optional UI baseline; UI tweaks reset on reload

--- a/custom_components/thermozona/__init__.py
+++ b/custom_components/thermozona/__init__.py
@@ -22,6 +22,7 @@ CONF_HEATING_BASE_OFFSET = "heating_base_offset"
 CONF_COOLING_BASE_OFFSET = "cooling_base_offset"
 CONF_FLOW_CURVE_OFFSET = "flow_curve_offset"
 CONF_CONTROL_MODE = "control_mode"
+CONF_FLOW_MODE = "flow_mode"
 CONF_PWM_CYCLE_TIME = "pwm_cycle_time"
 CONF_PWM_MIN_ON_TIME = "pwm_min_on_time"
 CONF_PWM_MIN_OFF_TIME = "pwm_min_off_time"
@@ -32,6 +33,9 @@ CONF_LICENSE_KEY = "license_key"
 
 CONTROL_MODE_BANG_BANG = "bang_bang"
 CONTROL_MODE_PWM = "pwm"
+
+FLOW_MODE_SIMPLE = "simple"
+FLOW_MODE_PRO_SUPERVISOR = "pro_supervisor"
 
 DEFAULT_HEATING_BASE_OFFSET = 3.0
 DEFAULT_COOLING_BASE_OFFSET = 2.5
@@ -102,6 +106,10 @@ CONFIG_SCHEMA = vol.Schema({
             CONF_FLOW_CURVE_OFFSET,
             default=DEFAULT_FLOW_CURVE_OFFSET,
         ): vol.Coerce(float),
+        vol.Optional(
+            CONF_FLOW_MODE,
+            default=FLOW_MODE_SIMPLE,
+        ): vol.In([FLOW_MODE_SIMPLE, FLOW_MODE_PRO_SUPERVISOR]),
         vol.Optional(CONF_LICENSE_KEY): cv.string,
         vol.Required(CONF_ZONES): {
             cv.string: ZONE_SCHEMA

--- a/custom_components/thermozona/licensing.py
+++ b/custom_components/thermozona/licensing.py
@@ -17,6 +17,8 @@ PRO_LICENSE_TIERS = {"pro", "sponsor"}
 
 PRO_LICENSE_DEFAULT_KEY_ID = "main-2026-01"
 
+# This key is part of Pro-license verification integrity (see NOTICE and
+# LICENSE-COMMERCIAL.md for tampering restrictions under commercial terms).
 PRO_LICENSE_PUBLIC_KEY_PEM = """-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEALt8+/pQOfUQRN3Sugun636DwGzabBdPCJ/D82Q8/oiI=
 -----END PUBLIC KEY-----"""

--- a/custom_components/thermozona/licensing.py
+++ b/custom_components/thermozona/licensing.py
@@ -3,10 +3,33 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import time
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 PRO_LICENSE_ISSUERS = {"thermozona", "thermozona.appventures.nl"}
 PRO_LICENSE_SOURCES = {"github_sponsors", "ghs"}
+PRO_LICENSE_TIERS = {"pro", "sponsor"}
+
+PRO_LICENSE_DEFAULT_KEY_ID = "main-2026-01"
+
+PRO_LICENSE_PUBLIC_KEY_PEM = """-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEALt8+/pQOfUQRN3Sugun636DwGzabBdPCJ/D82Q8/oiI=
+-----END PUBLIC KEY-----"""
+PRO_LICENSE_PUBLIC_KEY_PEM_ENV = "THERMOZONA_LICENSE_PUBLIC_KEY_PEM"
+PRO_LICENSE_PUBLIC_KEYS_JSON_ENV = "THERMOZONA_LICENSE_PUBLIC_KEYS_JSON"
+
+
+@dataclass(frozen=True)
+class LicenseValidationResult:
+    """Structured result of Pro license validation."""
+
+    is_valid: bool
+    reason: str
 
 
 def normalize_license_key(license_key: str | None) -> str:
@@ -20,17 +43,53 @@ def normalize_license_key(license_key: str | None) -> str:
 
 
 def is_pro_license_key(license_key: str | None) -> bool:
-    """Return True when the key is a valid GitHub sponsor token."""
-    normalized = normalize_license_key(license_key)
-    return is_github_sponsor_token(normalized)
+    """Return True when the key is a valid Pro license token."""
+    return validate_pro_license_key(license_key).is_valid
 
 
 def is_github_sponsor_token(license_key: str | None) -> bool:
-    """Return True when key is a valid (unexpired) GitHub sponsor token."""
+    """Backward-compatible alias for Pro license validation."""
+    return validate_pro_license_key(license_key).is_valid
+
+
+def validate_pro_license_key(license_key: str | None) -> LicenseValidationResult:
+    """Validate a Pro license JWT with signature and claim checks."""
     normalized = normalize_license_key(license_key)
-    payload = _decode_jwt_payload(normalized)
-    if payload is None:
-        return False
+    if not normalized:
+        return LicenseValidationResult(False, "missing_token")
+
+    decoded = _decode_jwt(normalized)
+    if decoded is None:
+        return LicenseValidationResult(False, "malformed_token")
+
+    header, payload, signing_input, signature = decoded
+
+    if header.get("alg") != "EdDSA":
+        return LicenseValidationResult(False, "unsupported_alg")
+
+    key_id = header.get("kid")
+    if key_id is not None and (not isinstance(key_id, str) or not key_id.strip()):
+        return LicenseValidationResult(False, "invalid_kid")
+
+    public_keys = _load_public_keys()
+    if public_keys is None:
+        return LicenseValidationResult(False, "public_key_load_failed")
+
+    if isinstance(key_id, str):
+        public_key = public_keys.get(key_id)
+        if public_key is None:
+            return LicenseValidationResult(False, "unknown_kid")
+    else:
+        public_key = public_keys.get(PRO_LICENSE_DEFAULT_KEY_ID)
+        if public_key is None and len(public_keys) == 1:
+            public_key = next(iter(public_keys.values()))
+        if public_key is None:
+            return LicenseValidationResult(False, "unknown_kid")
+
+    try:
+        public_key.verify(signature, signing_input)
+    except InvalidSignature:
+        return LicenseValidationResult(False, "invalid_signature")
 
     issuer = payload.get("iss")
     subject = payload.get("sub")
@@ -38,59 +97,120 @@ def is_github_sponsor_token(license_key: str | None) -> bool:
     tier = payload.get("tier")
 
     if issuer not in PRO_LICENSE_ISSUERS:
-        return False
+        return LicenseValidationResult(False, "invalid_issuer")
     if not isinstance(subject, str) or not subject.strip():
-        return False
+        return LicenseValidationResult(False, "invalid_subject")
     if source not in PRO_LICENSE_SOURCES:
-        return False
-    if tier not in {"pro", "sponsor"}:
-        return False
+        return LicenseValidationResult(False, "invalid_source")
+    if tier not in PRO_LICENSE_TIERS:
+        return LicenseValidationResult(False, "invalid_tier")
 
-    if not _is_payload_in_valid_time_window(payload):
-        return False
+    time_window_reason = _validate_payload_time_window(payload)
+    if time_window_reason is not None:
+        return LicenseValidationResult(False, time_window_reason)
 
-    return True
+    return LicenseValidationResult(True, "ok")
 
 
-def _decode_jwt_payload(token: str) -> dict | None:
-    """Decode JWT payload without signature verification."""
+def _decode_jwt(token: str) -> tuple[dict, dict, bytes, bytes] | None:
+    """Decode a JWT into header/payload/signature parts."""
     parts = token.split(".")
     if len(parts) != 3:
         return None
 
-    payload_segment = parts[1]
-    padded = payload_segment + "=" * ((4 - len(payload_segment) % 4) % 4)
     try:
-        raw_payload = base64.urlsafe_b64decode(padded.encode("ascii"))
-    except (ValueError, UnicodeEncodeError):
+        raw_header = _decode_base64url(parts[0])
+        raw_payload = _decode_base64url(parts[1])
+        signature = _decode_base64url(parts[2])
+    except ValueError:
         return None
 
     try:
+        header = json.loads(raw_header.decode("utf-8"))
         payload = json.loads(raw_payload.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return None
 
+    if not isinstance(header, dict):
+        return None
     if not isinstance(payload, dict):
         return None
-    return payload
+
+    signing_input = f"{parts[0]}.{parts[1]}".encode("ascii")
+    return header, payload, signing_input, signature
 
 
-def _is_payload_in_valid_time_window(payload: dict) -> bool:
+def _decode_base64url(value: str) -> bytes:
+    """Decode a base64url segment."""
+    padded = value + "=" * ((4 - len(value) % 4) % 4)
+    try:
+        return base64.urlsafe_b64decode(padded.encode("ascii"))
+    except (ValueError, UnicodeEncodeError) as err:
+        raise ValueError("invalid base64url") from err
+
+
+def _load_public_keys() -> dict[str, Ed25519PublicKey] | None:
+    """Load configured keyring used for Pro license verification."""
+    json_keys = os.getenv(PRO_LICENSE_PUBLIC_KEYS_JSON_ENV)
+    if json_keys:
+        try:
+            parsed = json.loads(json_keys)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        keys: dict[str, Ed25519PublicKey] = {}
+        for key_id, key_pem in parsed.items():
+            if not isinstance(key_id, str) or not key_id.strip():
+                return None
+            if not isinstance(key_pem, str) or not key_pem.strip():
+                return None
+            public_key = _load_single_public_key(key_pem)
+            if public_key is None:
+                return None
+            keys[key_id] = public_key
+
+        if not keys:
+            return None
+        return keys
+
+    public_pem = os.getenv(PRO_LICENSE_PUBLIC_KEY_PEM_ENV, PRO_LICENSE_PUBLIC_KEY_PEM)
+    public_key = _load_single_public_key(public_pem)
+    if public_key is None:
+        return None
+    return {PRO_LICENSE_DEFAULT_KEY_ID: public_key}
+
+
+def _load_single_public_key(public_pem: str) -> Ed25519PublicKey | None:
+    """Load one PEM public key as Ed25519."""
+    try:
+        key = serialization.load_pem_public_key(public_pem.encode("utf-8"))
+    except (TypeError, ValueError):
+        return None
+
+    if not isinstance(key, Ed25519PublicKey):
+        return None
+    return key
+
+
+def _validate_payload_time_window(payload: dict) -> str | None:
     """Validate exp/nbf/iat claims against current UTC timestamp."""
     now = int(time.time())
 
     exp = payload.get("exp")
     if not isinstance(exp, int) or exp <= now:
-        return False
+        return "token_expired"
 
     nbf = payload.get("nbf")
     if nbf is not None:
         if not isinstance(nbf, int) or nbf > now:
-            return False
+            return "token_not_yet_valid"
 
     iat = payload.get("iat")
     if iat is not None:
         if not isinstance(iat, int) or iat > now:
-            return False
+            return "token_issued_in_future"
 
-    return True
+    return None

--- a/custom_components/thermozona/manifest.json
+++ b/custom_components/thermozona/manifest.json
@@ -12,6 +12,8 @@
   "loggers": [
     "custom_components.thermozona"
   ],
-  "requirements": [],
+  "requirements": [
+    "cryptography>=42.0.0"
+  ],
   "version": "1.0.0"
 }

--- a/scripts/issue_pro_license.py
+++ b/scripts/issue_pro_license.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
-"""Issue signed Thermozona Pro license tokens."""
+"""Issue signed Thermozona Pro license tokens.
+
+Usage guide:
+- Set private key via THERMOZONA_LICENSE_PRIVATE_KEY_PEM (inline PEM) or
+  THERMOZONA_LICENSE_PRIVATE_KEY_PEM_PATH (path to PEM file).
+- Generate one JWT token on stdout for use as `license_key` in configuration.yaml.
+
+Example:
+  export THERMOZONA_LICENSE_PRIVATE_KEY_PEM_PATH=/secure/thermozona-private.pem
+  python scripts/issue_pro_license.py --sub github:japetheape --days 30 \
+    --issuer thermozona --source github_sponsors --tier pro --kid main-2026-01
+
+Security:
+- Never commit private keys to git.
+- Avoid exposing secrets in shell history or CI logs.
+"""
 from __future__ import annotations
 
 import argparse
@@ -48,7 +63,19 @@ def _load_private_key_from_env() -> Ed25519PrivateKey:
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Issue a Thermozona Pro JWT")
+    parser = argparse.ArgumentParser(
+        description="Issue a Thermozona Pro JWT",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Environment:\n"
+            "  THERMOZONA_LICENSE_PRIVATE_KEY_PEM       Inline private key PEM\n"
+            "  THERMOZONA_LICENSE_PRIVATE_KEY_PEM_PATH  Path to private key PEM\n\n"
+            "Example:\n"
+            "  python scripts/issue_pro_license.py --sub github:japetheape "
+            "--days 30 --issuer thermozona --source github_sponsors "
+            "--tier pro --kid main-2026-01"
+        ),
+    )
     parser.add_argument("--sub", required=True, help="Subject (user/account id)")
     parser.add_argument("--days", type=int, default=30, help="Token lifetime in days")
     parser.add_argument("--issuer", default="thermozona", help="JWT issuer claim")

--- a/scripts/issue_pro_license.py
+++ b/scripts/issue_pro_license.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Issue signed Thermozona Pro license tokens."""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from datetime import timedelta
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from custom_components.thermozona.licensing import PRO_LICENSE_SOURCES
+from custom_components.thermozona.licensing import PRO_LICENSE_DEFAULT_KEY_ID
+from custom_components.thermozona.licensing import PRO_LICENSE_TIERS
+
+PRIVATE_KEY_PEM_ENV = "THERMOZONA_LICENSE_PRIVATE_KEY_PEM"
+PRIVATE_KEY_PEM_PATH_ENV = "THERMOZONA_LICENSE_PRIVATE_KEY_PEM_PATH"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _load_private_key_from_env() -> Ed25519PrivateKey:
+    key_pem = os.getenv(PRIVATE_KEY_PEM_ENV)
+    if not key_pem:
+        key_path = os.getenv(PRIVATE_KEY_PEM_PATH_ENV)
+        if not key_path:
+            raise RuntimeError(
+                "Missing private key. Set THERMOZONA_LICENSE_PRIVATE_KEY_PEM "
+                "or THERMOZONA_LICENSE_PRIVATE_KEY_PEM_PATH"
+            )
+        key_pem = Path(key_path).read_text(encoding="utf-8")
+
+    key = serialization.load_pem_private_key(key_pem.encode("utf-8"), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise RuntimeError("Private key must be an Ed25519 key")
+    return key
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Issue a Thermozona Pro JWT")
+    parser.add_argument("--sub", required=True, help="Subject (user/account id)")
+    parser.add_argument("--days", type=int, default=30, help="Token lifetime in days")
+    parser.add_argument("--issuer", default="thermozona", help="JWT issuer claim")
+    parser.add_argument(
+        "--kid",
+        default=PRO_LICENSE_DEFAULT_KEY_ID,
+        help="Key identifier (JWT header kid)",
+    )
+    parser.add_argument(
+        "--source",
+        default="github_sponsors",
+        choices=sorted(PRO_LICENSE_SOURCES),
+        help="License source claim",
+    )
+    parser.add_argument(
+        "--tier",
+        default="pro",
+        choices=sorted(PRO_LICENSE_TIERS),
+        help="License tier claim",
+    )
+    parser.add_argument(
+        "--not-before-minutes",
+        type=int,
+        default=None,
+        help="Optional nbf claim offset in minutes (negative allows slight clock skew)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    subject = args.sub.strip()
+    if not subject:
+        raise RuntimeError("--sub must not be empty")
+    if args.days <= 0:
+        raise RuntimeError("--days must be greater than zero")
+    if not args.kid.strip():
+        raise RuntimeError("--kid must not be empty")
+
+    private_key = _load_private_key_from_env()
+
+    now = int(time.time())
+    payload = {
+        "iss": args.issuer,
+        "sub": subject,
+        "src": args.source,
+        "tier": args.tier,
+        "iat": now,
+        "exp": now + int(timedelta(days=args.days).total_seconds()),
+    }
+    if args.not_before_minutes is not None:
+        payload["nbf"] = now + args.not_before_minutes * 60
+
+    header = {"alg": "EdDSA", "typ": "JWT", "kid": args.kid.strip()}
+    encoded_header = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    encoded_payload = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("ascii")
+    signature = private_key.sign(signing_input)
+
+    token = f"{encoded_header}.{encoded_payload}.{_b64url(signature)}"
+    print(token)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as err:
+        print(f"Error: {err}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/verify_pro_license.py
+++ b/scripts/verify_pro_license.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Verify Thermozona Pro license tokens."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from custom_components.thermozona.licensing import validate_pro_license_key
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify a Thermozona Pro JWT")
+    parser.add_argument("token", help="JWT to verify")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = validate_pro_license_key(args.token)
+    if result.is_valid:
+        print("valid")
+        return 0
+
+    print(f"invalid: {result.reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace payload-only token checks with Ed25519 JWT signature verification plus strict claim/time validation for Pro licenses
- add Pro license tooling scripts to issue and verify signed tokens, including optional `kid` support for key rotation
- gate `flow_mode: pro_supervisor` behind valid Pro licenses with warning logs, and update docs/tests/config examples accordingly

## Testing
- python3 -m compileall custom_components scripts tests
- pytest was not run in this environment (`python3 -m pytest` unavailable)